### PR TITLE
Bug 1558530 - add instance shutdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The final step, then, is to start the worker with the derived configuration.
 ## Protocol
 
 This application defines a simple, text-based protocol between start-worker and the worker itself.
-The protocl ios defined in [protocol.md](protocol.md).
+The protocol is defined in [protocol.md](protocol.md).
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ With all of this complete, the run parameters are fully determined:
 
 The final step, then, is to start the worker with the derived configuration.
 
+## Protocol
+
+This application defines a simple, text-based protocol between start-worker and the worker itself.
+The protocl ios defined in [protocol.md](protocol.md).
+
 # Development
 
 This application requires go1.11.

--- a/cmd/start-worker/start.go
+++ b/cmd/start-worker/start.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/runner"
 	"github.com/taskcluster/taskcluster-worker-runner/secrets"
@@ -71,7 +72,34 @@ func StartWorker(runnercfg *runner.RunnerConfig) error {
 	// start
 
 	log.Printf("Starting worker")
-	err = worker.StartWorker(&run)
+	transp, err := worker.StartWorker(&run)
+	if err != nil {
+		return err
+	}
+
+	// set up protocol
+
+	proto := protocol.NewProtocol(transp)
+	provider.SetProtocol(proto)
+	worker.SetProtocol(proto)
+
+	// call this before starting the proto so that there are no race conditions
+	// around the capabilities negotiation
+	err = provider.WorkerStarted()
+	if err != nil {
+		return err
+	}
+
+	proto.Start(false)
+
+	// wait for the worker to terminate
+
+	err = worker.Wait()
+	if err != nil {
+		return err
+	}
+
+	err = provider.WorkerFinished()
 	if err != nil {
 		return err
 	}

--- a/protocol.md
+++ b/protocol.md
@@ -1,0 +1,53 @@
+# Runner / Worker Protocol
+
+Start-worker implements a simple protocol for communication between the application and workers.
+This is a line-based protocol that runs over the worker's stdin/stdout files.
+
+The intent of this protocol is that it is simple for workers to implement desired features, and does not tie workers to any particular cloud provider or other technology.
+
+Using stdin/stdout has a few advantages:
+ - it's secure: no other process can access these connections
+ - it's simple to implement
+ - it's available on all platforms
+
+## Message Encoding
+
+Each message is in the form of a newline-terminated line of the form
+
+```
+~{...}
+```
+
+with the `{...}` being a JSON encoding of the message containing at least a `type` property, as described below.
+
+Any line that does not match this pattern is output to the receiving process's stdout in the expectation that it will be fed to a log aggregator.
+Note that stderr is not included in the protocol.
+
+## Go Package
+
+The `github.com/taskcluster/taskcluster-worker-runner/protocol` package contains an implementation of this protocol suitable for use by `start-worker` and by a worker.
+
+## Initialization and Capability Negotiation
+
+On startup, start-worker writes a message with type `welcome`, containing an array of capabilities it supports.
+```
+~{"type": "welcome", "capabilities": [...]}
+```
+
+The worker should read this message and reply with `hello`, containing an array of capabilities that is a subset of that provided by start-worker.
+The capabilities in the `hello` message become the capabilities for this run, and no messages or functionality not associated with those capabilities can be used by either process.
+
+That array may be empty, indicating no capabilities.
+Since all messages aside from `welcome` and `hello` are associated with a capability, the simplest valid implementation of a worker is simply to write
+```
+~{"type": "hello", "capabilities": []}
+```
+on startup and nothing more.
+
+If a worker is run outside of a taskcluster-worker-runner context, it will never see the `welcome` message and thus never write `hello` or any other message.
+
+## Messages
+
+The following sections describe the defined message types, each under a heading giving the corresponding capability.
+
+_(none yet)_

--- a/protocol.md
+++ b/protocol.md
@@ -50,4 +50,17 @@ If a worker is run outside of a taskcluster-worker-runner context, it will never
 
 The following sections describe the defined message types, each under a heading giving the corresponding capability.
 
-_(none yet)_
+### graceful-termination
+
+Graceful termination is a way of indicating that the worker should shut down gracefully but quickly.
+Typically, workers should stop claiming tasks and resolve any running tasks as `worker-shutdown`.
+
+Graceful termination is initiated by a message from start-worker containing a `finish-tasks` property.
+If this property is true, the worker may take the time to finish any running tasks.
+If false, then shutdown is imminent and the worker should simply clean up and exit.
+
+```
+~{"type": "graceful-termination", "finish-tasks": false}
+```
+
+There is no reponse message.

--- a/protocol/capabilities.go
+++ b/protocol/capabilities.go
@@ -1,0 +1,64 @@
+package protocol
+
+import "sort"
+
+var KnownCapabilities = []string{
+	"graceful-termination",
+}
+
+type Capabilities struct {
+	// use a map as a poor-man's set
+	capabilities map[string]bool
+}
+
+func EmptyCapabilities() *Capabilities {
+	return &Capabilities{
+		capabilities: make(map[string]bool),
+	}
+}
+
+func FullCapabilities() *Capabilities {
+	return FromCapabilitiesList(KnownCapabilities)
+}
+
+func FromCapabilitiesList(caplist []string) *Capabilities {
+	caps := make(map[string]bool)
+	for _, c := range caplist {
+		caps[c] = true
+	}
+	return &Capabilities{
+		capabilities: caps,
+	}
+}
+
+func (caps *Capabilities) List() []string {
+	rv := make([]string, 0, len(caps.capabilities))
+	for c := range caps.capabilities {
+		rv = append(rv, c)
+	}
+	sort.Strings(rv)
+	return rv
+}
+
+func (caps *Capabilities) Add(c string) {
+	caps.capabilities[c] = true
+}
+
+func (caps *Capabilities) Remove(c string) {
+	delete(caps.capabilities, c)
+}
+
+func (caps *Capabilities) Has(c string) bool {
+	_, has := caps.capabilities[c]
+	return has
+}
+
+func (caps *Capabilities) LimitTo(other *Capabilities) {
+	newcaps := make(map[string]bool)
+	for c := range caps.capabilities {
+		if other.Has(c) {
+			newcaps[c] = true
+		}
+	}
+	caps.capabilities = newcaps
+}

--- a/protocol/capabilities_test.go
+++ b/protocol/capabilities_test.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyCapabilities(t *testing.T) {
+	assert.Equal(t, EmptyCapabilities().List(), []string{})
+}
+
+func TestFromCapabilitiesList(t *testing.T) {
+	caps := []string{"abc", "def"}
+	assert.Equal(t, FromCapabilitiesList(caps).List(), caps)
+}
+
+func TestAdd(t *testing.T) {
+	caps := EmptyCapabilities()
+	caps.Add("abc")
+	assert.Equal(t, caps.List(), []string{"abc"})
+}
+
+func TestRemove(t *testing.T) {
+	caps := FullCapabilities()
+	assert.True(t, caps.Has("graceful-termination"))
+	caps.Remove("graceful-termination")
+	assert.False(t, caps.Has("graceful-termination"))
+	caps.Remove("graceful-termination")
+	assert.False(t, caps.Has("graceful-termination"))
+}
+
+func TestLimitTo(t *testing.T) {
+	caps1 := FromCapabilitiesList([]string{"abc", "def"})
+	caps2 := FromCapabilitiesList([]string{"def", "ghi"})
+	caps1.LimitTo(caps2)
+	assert.False(t, caps1.Has("abc"))
+	assert.True(t, caps1.Has("def"))
+	assert.False(t, caps1.Has("ghi"))
+}

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Message struct {
+	Type       string
+	Properties map[string]interface{}
+}
+
+func (msg *Message) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, &msg.Properties)
+	if err != nil {
+		return err
+	}
+
+	typ, ok := msg.Properties["type"]
+	if !ok {
+		return fmt.Errorf("Message has no 'type' property")
+	}
+
+	msg.Type, ok = typ.(string)
+	if !ok {
+		return fmt.Errorf("Message 'type' property is not a string")
+	}
+
+	delete(msg.Properties, "type")
+	return nil
+}
+
+func (msg *Message) MarshalJSON() ([]byte, error) {
+	obj := make(map[string]interface{})
+	for k, v := range msg.Properties {
+		obj[k] = v
+	}
+	obj["type"] = msg.Type
+	return json.Marshal(obj)
+}

--- a/protocol/message_test.go
+++ b/protocol/message_test.go
@@ -1,0 +1,49 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageMarshal(t *testing.T) {
+	msg := Message{
+		Type: "hey-you",
+		Properties: map[string]interface{}{
+			"x": true,
+			"y": "twenty",
+		},
+	}
+	bytes, err := json.Marshal(&msg)
+	assert.NoError(t, err, "should not fail")
+
+	var obj map[string]interface{}
+	err = json.Unmarshal(bytes, &obj)
+	assert.NoError(t, err, "should not fail")
+
+	assert.Equal(t, "hey-you", obj["type"], "did not get expected type property")
+	assert.Equal(t, true, obj["x"], "did not get expected x property")
+	assert.Equal(t, "twenty", obj["y"], "did not get expected y property")
+}
+
+func TestMessageUnmarshal(t *testing.T) {
+	var msg Message
+	err := json.Unmarshal([]byte(`{"type": "hey-you", "value": "sure"}`), &msg)
+	assert.NoError(t, err, "should not fail")
+
+	assert.Equal(t, "hey-you", msg.Type, "did not get expected properties")
+	assert.Equal(t, map[string]interface{}{"value": "sure"}, msg.Properties, "did not get expected properties")
+}
+
+func TestMessageUnmarshalNoType(t *testing.T) {
+	var msg Message
+	err := json.Unmarshal([]byte(`{"value": "sure"}`), &msg)
+	assert.Error(t, err, "should fail")
+}
+
+func TestMessageUnmarshalBadType(t *testing.T) {
+	var msg Message
+	err := json.Unmarshal([]byte(`{"type": true, "value": "sure"}`), &msg)
+	assert.Error(t, err, "should fail")
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,0 +1,97 @@
+package protocol
+
+type MessageCallback func(msg Message)
+
+type Protocol struct {
+	// transport over which this protocol is running
+	transport Transport
+
+	// current set of agreed capabilities
+	Capabilities *Capabilities
+
+	// callbacks per message type
+	callbacks map[string][]MessageCallback
+}
+
+func NewProtocol(transport Transport) *Protocol {
+	return &Protocol{
+		transport:    transport,
+		Capabilities: EmptyCapabilities(),
+		callbacks:    make(map[string][]MessageCallback),
+	}
+}
+
+// Register a callback for the given message type.  This must occur before the
+// protocol is started.
+func (prot *Protocol) Register(messageType string, callback MessageCallback) {
+	callbacks := prot.callbacks[messageType]
+	callbacks = append(callbacks, callback)
+	prot.callbacks[messageType] = callbacks
+}
+
+// convert an anymous interface into a list of strings; useful for parsing lists
+// out of messages
+func listOfStrings(val interface{}) []string {
+	aslist := val.([]interface{})
+	rv := make([]string, 0, len(aslist))
+	for _, elt := range aslist {
+		rv = append(rv, elt.(string))
+	}
+	return rv
+}
+
+// Start the protocol and initiate the hello/welcome transaction.
+func (prot *Protocol) Start(asWorker bool) {
+	if asWorker {
+		prot.Register("welcome", func(msg Message) {
+			caps := FullCapabilities()
+			otherCaps := FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
+			caps.LimitTo(otherCaps)
+			prot.Capabilities = caps
+
+			prot.Send(Message{
+				Type: "hello",
+				Properties: map[string]interface{}{
+					"capabilities": prot.Capabilities.List(),
+				},
+			})
+		})
+	} else {
+		prot.Register("hello", func(msg Message) {
+			prot.Capabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
+		})
+
+		fullCaps := FullCapabilities()
+		prot.Send(Message{
+			Type: "welcome",
+			Properties: map[string]interface{}{
+				"capabilities": fullCaps.List(),
+			},
+		})
+	}
+	go prot.recvLoop()
+}
+
+// Check if a capability is supported.  Note that the initial set
+// of capabilities is empty, so calling this before the hello/welcome
+// transaction has been completed will always return false.
+func (prot *Protocol) Capable(c string) bool {
+	return prot.Capabilities.Has(c)
+}
+
+func (prot *Protocol) Send(msg Message) {
+	prot.transport.Send(msg)
+}
+
+func (prot *Protocol) recvLoop() {
+	for {
+		msg, ok := prot.transport.Recv()
+		if !ok {
+			return
+		}
+		callbacks := prot.callbacks[msg.Type]
+		for _, cb := range callbacks {
+			cb(msg)
+		}
+	}
+}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocol(t *testing.T) {
+	runnerTransp := NewStdioTransport()
+	workerTransp := NewStdioTransport()
+
+	// wire those together in both directions, and finish them at
+	// the end of the test
+	go func() {
+		_, err := io.Copy(runnerTransp, workerTransp)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	go func() {
+		_, err := io.Copy(workerTransp, runnerTransp)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	defer runnerTransp.Close()
+	defer workerTransp.Close()
+
+	runnerProto := NewProtocol(runnerTransp)
+	workerProto := NewProtocol(workerTransp)
+
+	gotWelcome := false
+	var welcomeCaps []string
+	workerProto.Register("welcome", func(msg Message) {
+		gotWelcome = true
+		welcomeCaps = listOfStrings(msg.Properties["capabilities"])
+	})
+
+	done := make(chan bool)
+	var helloCaps []string
+	runnerProto.Register("hello", func(msg Message) {
+		helloCaps = listOfStrings(msg.Properties["capabilities"])
+		close(done)
+	})
+
+	runnerProto.Start(false)
+	workerProto.Start(true)
+
+	<-done
+	assert.True(t, gotWelcome)
+	assert.Equal(t, welcomeCaps, KnownCapabilities)
+	assert.Equal(t, helloCaps, KnownCapabilities)
+}

--- a/protocol/transport.go
+++ b/protocol/transport.go
@@ -1,0 +1,189 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+)
+
+// Transport is a means of sending and receiving messages.
+type Transport interface {
+	// Send a message to the worker
+	Send(Message)
+
+	// Receive a message from the worker, blocking until one is availble
+	Recv() (Message, bool)
+}
+
+// StdioTransport implements the worker-runner protocol over stdin/stdout.  It
+// implements Transport, io.Reader and io.WriteCloser, where it uses the
+// encoding defined in `protocol.md`, and exposes channels of incoming and
+// outgoing messages.
+type StdioTransport struct {
+	// channels of incoming and outgoing messages
+	In  chan Message
+	Out chan Message
+
+	// a writer to which invalid lines are written, defaulting to
+	// os.Stdout
+	InvalidLines io.Writer
+
+	// protects access to inBuffer (outbuffer has no contention)
+	inMux sync.Mutex
+
+	inBuffer  []byte
+	outBuffer []byte
+}
+
+// Create a new StdioTransport and attach it to the given Cmd object
+// by setting cmd.Stdin and cmd.Stdout appropriately.
+func NewStdioTransport() *StdioTransport {
+	return &StdioTransport{
+		In:           make(chan Message, 5),
+		Out:          make(chan Message, 5),
+		InvalidLines: os.Stdout,
+	}
+}
+
+// protocol.Transport interface
+
+func (transp *StdioTransport) Send(msg Message) {
+	transp.Out <- msg
+}
+
+func (transp *StdioTransport) Recv() (Message, bool) {
+	m, ok := <-transp.In
+	return m, ok
+}
+
+// io.Reader implementation
+
+func (transp *StdioTransport) Read(p []byte) (int, error) {
+	// if the buffer is empty, block waiting for a message
+	if len(transp.outBuffer) == 0 {
+		msg, ok := <-transp.Out
+		if !ok {
+			return 0, io.EOF
+		}
+		j, err := json.Marshal(&msg)
+		if err != nil {
+			return 0, err
+		}
+		transp.outBuffer = append(append(append(transp.outBuffer, '~'), j...), '\n')
+	}
+
+	// we now have a nonempty buffer, so read from it
+	l := len(transp.outBuffer)
+	if l > len(p) {
+		l = len(p)
+	}
+	copy(p, transp.outBuffer[:l])
+	transp.outBuffer = transp.outBuffer[l:]
+	return l, nil
+}
+
+// io.Writer implementation
+
+func (transp *StdioTransport) Write(p []byte) (int, error) {
+	transp.inMux.Lock()
+	defer transp.inMux.Unlock()
+	if len(transp.inBuffer) == 0 {
+		transp.inBuffer = p
+	} else {
+		transp.inBuffer = append(transp.inBuffer, p...)
+	}
+
+	// break inBuffer into full lines, handling each one in turn
+	for {
+		newline := bytes.IndexRune(transp.inBuffer, '\n')
+		if newline == -1 {
+			break
+		}
+
+		line := transp.inBuffer[:newline]
+
+		invalid := false
+		var err error
+
+		if len(line) < 3 || line[0] != '~' || line[1] != '{' || line[len(line)-1] != '}' {
+			invalid = true
+		}
+
+		var msg Message
+		if !invalid {
+			err = json.Unmarshal(line[1:], &msg)
+			if err != nil {
+				invalid = true
+			}
+		}
+
+		if invalid {
+			// write the whole line, including the newline, to InvalidLines
+			n, err := transp.InvalidLines.Write(transp.inBuffer[:newline+1])
+			if err != nil {
+				transp.inBuffer = transp.inBuffer[n:]
+				return n, err
+			}
+		} else {
+			transp.In <- msg
+		}
+
+		transp.inBuffer = transp.inBuffer[newline+1:]
+	}
+
+	return len(p), nil
+}
+
+func (transp *StdioTransport) Close() error {
+	transp.inMux.Lock()
+	defer transp.inMux.Unlock()
+	// flush any remaining buffered input as invalid..
+	if len(transp.inBuffer) != 0 {
+		_, err := transp.InvalidLines.Write(transp.inBuffer)
+		if err != nil {
+			return err
+		}
+	}
+
+	close(transp.In)
+
+	return nil
+}
+
+// NullTransport implements Transport without doing anything.  It's suitable for
+// workers that do not implement the protocol
+type NullTransport struct{}
+
+func NewNullTransport() *NullTransport {
+	return &NullTransport{}
+}
+
+func (transp *NullTransport) Send(msg Message) {
+	// sent messages are lost..
+}
+
+func (transp *NullTransport) Recv() (Message, bool) {
+	// no messages are ever received
+	select {}
+}
+
+// FakeTransport implements Transport and records sent messages.  It is used
+// for testing.
+type FakeTransport struct {
+	Messages []Message
+}
+
+func NewFakeTransport() *FakeTransport {
+	return &FakeTransport{Messages: []Message{}}
+}
+
+func (transp *FakeTransport) Send(msg Message) {
+	transp.Messages = append(transp.Messages, msg)
+}
+
+func (transp *FakeTransport) Recv() (Message, bool) {
+	// no messages are ever received
+	select {}
+}

--- a/protocol/transport_test.go
+++ b/protocol/transport_test.go
@@ -1,0 +1,149 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Write the given data in chunks of the given size
+func writeInChunks(data []byte, chunkSize int, writer io.WriteCloser) error {
+	for {
+		if len(data) == 0 {
+			break
+		}
+
+		if len(data) >= chunkSize {
+			chunkSize = len(data)
+		}
+		n, err := writer.Write(data[:chunkSize])
+		if err != nil {
+			return err
+		}
+		if n < chunkSize {
+			return fmt.Errorf("Write returned < input size without an error (interface contract violation")
+		}
+		data = data[chunkSize:]
+	}
+
+	err := writer.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Read messages from a message channel and write them to an array
+func readMessages(source chan Message, dest *[]Message) {
+	for m := range source {
+		*dest = append(*dest, m)
+	}
+}
+
+var testWriterData = []byte(`
+~{"type": "abc"}
+not a message
+~{"type": "bcdf", "lengthy": "abc abc abc abc abc abc abc abc abc abc abc abc abc abc"}
+~{"type": "not valid JSON}
+`[1:])
+
+func doTestWriter(t *testing.T, chunkSize int) {
+	transp := NewStdioTransport()
+
+	var invalid bytes.Buffer
+	transp.InvalidLines = &invalid
+
+	err := writeInChunks(testWriterData, chunkSize, transp)
+	assert.NoError(t, err, "should not fail")
+
+	// note that this depends on the channel having capacity for all of the messages
+
+	var got []Message
+	readMessages(transp.In, &got)
+	assert.Equal(t, []Message{
+		Message{Type: "abc", Properties: map[string]interface{}{}},
+		Message{Type: "bcdf", Properties: map[string]interface{}{"lengthy": "abc abc abc abc abc abc abc abc abc abc abc abc abc abc"}},
+	}, got, "should have gotten two messages")
+
+	assert.Equal(t, `
+not a message
+~{"type": "not valid JSON}
+`[1:], invalid.String(), "expected two invalid lines")
+}
+
+func TestWriterFullSize(t *testing.T) {
+	doTestWriter(t, len(testWriterData))
+}
+
+func TestWriterByteAtATime(t *testing.T) {
+	doTestWriter(t, 1)
+}
+
+func TestWriterFirstLine(t *testing.T) {
+	doTestWriter(t, bytes.IndexByte(testWriterData, byte('\n')))
+}
+
+func TestWriterFirstLinePlusNewlin(t *testing.T) {
+	doTestWriter(t, bytes.IndexByte(testWriterData, byte('\n'))+1)
+}
+
+func TestReaderBigChunk(t *testing.T) {
+	transp := NewStdioTransport()
+
+	transp.Out <- Message{Type: "abc", Properties: map[string]interface{}{}}
+	transp.Out <- Message{Type: "def", Properties: map[string]interface{}{"x": true}}
+	transp.Out <- Message{Type: "def", Properties: map[string]interface{}{"x": false}}
+	close(transp.Out)
+
+	var result bytes.Buffer
+	_, err := io.Copy(&result, transp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `
+~{"type":"abc"}
+~{"type":"def","x":true}
+~{"type":"def","x":false}
+`[1:], result.String())
+}
+
+func TestReaderByteAtATime(t *testing.T) {
+	transp := NewStdioTransport()
+
+	transp.Out <- Message{Type: "abc", Properties: map[string]interface{}{}}
+	transp.Out <- Message{Type: "def", Properties: map[string]interface{}{"x": true}}
+	transp.Out <- Message{Type: "def", Properties: map[string]interface{}{"x": false}}
+	close(transp.Out)
+
+	var result []byte
+	for {
+		b := make([]byte, 1)
+		n, err := transp.Read(b)
+		if err == io.EOF {
+			assert.Equal(t, 0, n)
+			break
+		}
+		assert.NoError(t, err)
+		result = append(result, b[:n]...)
+	}
+
+	assert.Equal(t, `
+~{"type":"abc"}
+~{"type":"def","x":true}
+~{"type":"def","x":false}
+`[1:], string(result))
+}
+
+func TestReaderUnmarshalable(t *testing.T) {
+	transp := NewStdioTransport()
+
+	transp.Out <- Message{Type: "def", Properties: map[string]interface{}{"x": make(chan int)}}
+	close(transp.Out)
+
+	var result bytes.Buffer
+	_, err := io.Copy(&result, transp)
+	assert.Error(t, err)
+}

--- a/provider/awsprovisioner/metadata.go
+++ b/provider/awsprovisioner/metadata.go
@@ -35,17 +35,14 @@ type MetadataService interface {
 
 type realMetadataService struct{}
 
-// TODO: rewrite in terms of mds.queryMetadata
 func (mds *realMetadataService) queryUserData() (*UserData, error) {
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-user-data-retrieval
-	resp, _, err := httpbackoff.Get(EC2MetadataBaseURL + "/user-data")
+	content, err := mds.queryMetadata("/user-data")
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	userData := &UserData{}
-	decoder := json.NewDecoder(resp.Body)
-	err = decoder.Decode(userData)
+	err = json.Unmarshal([]byte(content), userData)
 	return userData, err
 }
 

--- a/provider/awsprovisioner/metadata_test.go
+++ b/provider/awsprovisioner/metadata_test.go
@@ -1,6 +1,14 @@
 package awsprovisioner
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/httpbackoff"
+)
 
 type fakeMetadataService struct {
 	UserDataError error
@@ -26,4 +34,57 @@ func (mds *fakeMetadataService) queryMetadata(path string) (string, error) {
 	return res, nil
 }
 
-// TODO: test the real metadata service
+func TestQueryMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/meta-data/some-data" {
+			w.WriteHeader(200)
+			fmt.Fprintln(w, "42")
+		} else {
+			w.WriteHeader(404)
+			fmt.Fprintln(w, "Not Found")
+		}
+	}))
+	defer ts.Close()
+
+	EC2MetadataBaseURL = ts.URL + "/latest"
+	defer func() {
+		EC2MetadataBaseURL = "http://169.254.169.254/latest"
+	}()
+
+	ms := realMetadataService{}
+
+	rv, err := ms.queryMetadata("/meta-data/some-data")
+	assert.NoError(t, err)
+	assert.Equal(t, "42\n", rv)
+
+	_, err = ms.queryMetadata("/meta-data/NOSUCH")
+	if assert.Error(t, err) {
+		httperr, ok := err.(httpbackoff.BadHttpResponseCode)
+		assert.True(t, ok)
+		assert.Equal(t, 404, httperr.HttpResponseCode)
+	}
+}
+
+func TestQueryUserData(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/user-data" {
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"region": "aa-central-2"}`)
+		} else {
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "Not Found: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	EC2MetadataBaseURL = ts.URL + "/latest"
+	defer func() {
+		EC2MetadataBaseURL = "http://169.254.169.254/latest"
+	}()
+
+	ms := realMetadataService{}
+
+	ud, err := ms.queryUserData()
+	assert.NoError(t, err)
+	assert.Equal(t, "aa-central-2", ud.Region)
+}

--- a/provider/provider/iface.go
+++ b/provider/provider/iface.go
@@ -1,6 +1,9 @@
 package provider
 
-import "github.com/taskcluster/taskcluster-worker-runner/runner"
+import (
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+)
 
 // Provider is responsible for determining the identity of this worker and gathering
 // Takcluster credentials.
@@ -8,4 +11,19 @@ type Provider interface {
 	// Configure the given run.  This is expected to set the Taskcluster deployment
 	// and worker-information fields, but may modify any part of the run it desires.
 	ConfigureRun(run *runner.Run) error
+
+	// Set the protocol used for communication with this worker.  This is an appropriate
+	// time to register for interesting messages from the worker.
+	SetProtocol(proto *protocol.Protocol)
+
+	// The worker has started.  This is an appropriate time to set up any
+	// provider-specific things that should occur while the worker is running.
+	// Note that this is called before the protocol has started, so it will still
+	// have no capabilities.
+	WorkerStarted() error
+
+	// The worker has exited.  Handle any necessary communication with the provider.
+	// Note that this method may not always be called, e.g., in the event of a system
+	// failure.
+	WorkerFinished() error
 }

--- a/provider/standalone/standalone.go
+++ b/provider/standalone/standalone.go
@@ -1,6 +1,7 @@
 package standalone
 
 import (
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/runner"
 )
@@ -34,6 +35,17 @@ func (p *StandaloneProvider) ConfigureRun(run *runner.Run) error {
 
 	run.WorkerConfig = run.WorkerConfig.Merge(nil)
 
+	return nil
+}
+
+func (p *StandaloneProvider) SetProtocol(proto *protocol.Protocol) {
+}
+
+func (p *StandaloneProvider) WorkerStarted() error {
+	return nil
+}
+
+func (p *StandaloneProvider) WorkerFinished() error {
 	return nil
 }
 

--- a/worker/dummy/dummy.go
+++ b/worker/dummy/dummy.go
@@ -3,6 +3,7 @@ package dummy
 import (
 	"log"
 
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/runner"
 	"github.com/taskcluster/taskcluster-worker-runner/worker/worker"
 	yaml "gopkg.in/yaml.v3"
@@ -16,12 +17,19 @@ func (d *dummy) ConfigureRun(run *runner.Run) error {
 	return nil
 }
 
-func (d *dummy) StartWorker(run *runner.Run) error {
+func (d *dummy) StartWorker(run *runner.Run) (protocol.Transport, error) {
 	out, err := yaml.Marshal(run)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.Printf("Run information:\n%s", out)
+	return protocol.NewNullTransport(), nil
+}
+
+func (d *dummy) SetProtocol(proto *protocol.Protocol) {
+}
+
+func (d *dummy) Wait() error {
 	return nil
 }
 

--- a/worker/worker/worker.go
+++ b/worker/worker/worker.go
@@ -1,6 +1,9 @@
 package worker
 
-import "github.com/taskcluster/taskcluster-worker-runner/runner"
+import (
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+)
 
 // Worker is responsible for determining the identity of this worker and gathering
 // Takcluster credentials.
@@ -9,6 +12,13 @@ type Worker interface {
 	// and worker-information fields, but may modify any part of the run it desires.
 	ConfigureRun(run *runner.Run) error
 
-	// Actually start the worker.
-	StartWorker(run *runner.Run) error
+	// Actually start the worker, returning once it has been started.
+	StartWorker(run *runner.Run) (protocol.Transport, error)
+
+	// Set the protocol used for communication with this worker.  This is an appropriate
+	// time to register for interesting messages from the worker.
+	SetProtocol(proto *protocol.Protocol)
+
+	// Wait for the worker to terminate
+	Wait() error
 }


### PR DESCRIPTION
This involves a few big chunks of functionality:
 * `start-worker` keeps running while the worker is runnig, doing its own thing
 * a new communication protocol between start-worker and the worker itself
   * bidirectional and async - either side can send a message at any time
   * carried over the worker's stdio pipes, preventing hijacking
   * simple capabilities negotiation allows independent evolution of both sides of the protocol
 * AwsProvisionerProvider polls the EC2 metadata service every 30 seconds for a spot termination notification, sending a `graceful-termination` message to the worker if it is capable.

The unit tests indicate this is functional, but no workers yet implement the protocol so there may still be bugs!

https://bugzilla.mozilla.org/show_bug.cgi?id=1558530