### PR TITLE
Bug 1562975 - implement a static provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ configuration:
 		workerGroup: ..
 		workerID: ..
 
+### static
+
+The providerType "static" is intended for workers provisioned with worker-manager
+providers using providerType "static".  It requires
+
+	provider:
+		providerType: static
+		rootURL: ...
+		providerID: ...
+		workerPoolID: ...
+		workerGroup: ...
+		workerID: ...
+		identitySecret: ... // shared secret configured for this worker in worker-manager
+
 
 ## Workers
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Usage:
 	start-worker <runnerConfig>
 
 
-Configuration is in the form of a YAML file with the following fields:
+## Configuration
+
+Configuration for this process is in the form of a YAML file with the following fields:
 
 	provider: (required) information about the provider for this worker
 
@@ -29,25 +31,40 @@ Configuration is in the form of a YAML file with the following fields:
 
 	worker: (required) information about the worker being run
 
-		implementation: (required) the name of the worker implementation
+		implementation: (required) the name of the worker implementation; see below.
 
 	workerConfig: arbitrary data which forms the basics of the config passed to the worker;
 		this will be merged with several other sources of configuration.
 
 
+## Providers
 
 Providers configuration depends on the providerType:
+
+### aws-provisioner
 
 The providerType "aws-provisioner" is intended for workers provisioned with
 the legacy aws-provisioner application.  It requires 
 
 	provider:
-	    providerType: aws-provisioner
+		providerType: aws-provisioner
 
+### google
+
+The providerType "google" is intended for workers provisioned with worker-manager
+providers using providerType "google".  It requires
+
+	provider:
+		providerType: google
+
+### standalone
 
 The providerType "standalone" is intended for workers that have all of their
-configuration pre-loaded.  It requires the following properties be included
-explicitly in the runner configuration:
+configuration pre-loaded.  Such workers do not interact with the worker manager.
+This is not a recommended configuration - prefer to use the static provider.
+
+It requires the following properties be included explicitly in the runner
+configuration:
 
 	provider:
 		providerType: standalone
@@ -59,9 +76,11 @@ explicitly in the runner configuration:
 		workerID: ..
 
 
+## Workers
 
 The following worker implementations are supported:
 
+### docker-worker
 
 The "docker-worker" worker implementation starts docker-worker
 (https://github.com/taskcluster/docker-worker).  It takes the following
@@ -75,7 +94,7 @@ values in the 'worker' section of the runner configuration:
 		# docker-worker configuration.
 		configPath: ..
 
-
+### dummy
 
 The "dummy" worker implementation does nothing but dump the run instead of
 "starting" anything.  It is intended for debugging.

--- a/cfg/providerconfig.go
+++ b/cfg/providerconfig.go
@@ -12,16 +12,16 @@ import (
 // plus any additional provider-specific properties.
 type ProviderConfig struct {
 	ProviderType string
-	data         map[string]interface{}
+	Data         map[string]interface{}
 }
 
 func (pc *ProviderConfig) UnmarshalYAML(node *yaml.Node) error {
-	err := node.Decode(&pc.data)
+	err := node.Decode(&pc.Data)
 	if err != nil {
 		return err
 	}
 
-	pt, ok := pc.data["providerType"]
+	pt, ok := pc.Data["providerType"]
 	if !ok {
 		return fmt.Errorf("provider config must have a `providerType` property")
 	}
@@ -30,7 +30,7 @@ func (pc *ProviderConfig) UnmarshalYAML(node *yaml.Node) error {
 	if !ok {
 		return fmt.Errorf("provider config's `providerType` property must be a string")
 	}
-	delete(pc.data, "providerType")
+	delete(pc.Data, "providerType")
 
 	return nil
 }
@@ -63,7 +63,7 @@ func (pc *ProviderConfig) Unpack(out interface{}) error {
 		}
 
 		// get the value
-		val, ok := pc.data[name]
+		val, ok := pc.Data[name]
 		if !ok {
 			return fmt.Errorf("Configuration value `provider.%s` not found", name)
 		}

--- a/cfg/providerconfig_test.go
+++ b/cfg/providerconfig_test.go
@@ -37,7 +37,7 @@ func TestProviderOK(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}
 
-	assert.Equal(t, map[string]interface{}{"value": "sure"}, pc.data, "did not get expected config")
+	assert.Equal(t, map[string]interface{}{"value": "sure"}, pc.Data, "did not get expected config")
 }
 
 func TestProviderUnpack(t *testing.T) {

--- a/cmd/start-worker/start.go
+++ b/cmd/start-worker/start.go
@@ -80,11 +80,17 @@ func StartWorker(runnercfg *runner.RunnerConfig) error {
 	// set up protocol
 
 	proto := protocol.NewProtocol(transp)
+	run.SetProtocol(proto)
 	provider.SetProtocol(proto)
 	worker.SetProtocol(proto)
 
 	// call this before starting the proto so that there are no race conditions
 	// around the capabilities negotiation
+	err = run.WorkerStarted()
+	if err != nil {
+		return err
+	}
+
 	err = provider.WorkerStarted()
 	if err != nil {
 		return err
@@ -100,6 +106,11 @@ func StartWorker(runnercfg *runner.RunnerConfig) error {
 	}
 
 	err = provider.WorkerFinished()
+	if err != nil {
+		return err
+	}
+
+	err = run.WorkerFinished()
 	if err != nil {
 		return err
 	}

--- a/provider/awsprovisioner/awsprovisioner.go
+++ b/provider/awsprovisioner/awsprovisioner.go
@@ -169,7 +169,7 @@ The providerType "aws-provisioner" is intended for workers provisioned with
 the legacy aws-provisioner application.  It requires 
 
 	provider:
-	    providerType: aws-provisioner
+		providerType: aws-provisioner
 `
 }
 

--- a/provider/awsprovisioner/awsprovisioner.go
+++ b/provider/awsprovisioner/awsprovisioner.go
@@ -53,6 +53,9 @@ func (p *AwsProvisionerProvider) ConfigureRun(run *runner.Run) error {
 	run.Credentials.AccessToken = secToken.Credentials.AccessToken
 	run.Credentials.Certificate = secToken.Credentials.Certificate
 
+	// aws-provisioner always provides 96-hour credentials
+	run.CredentialsExpire = time.Now().Add(96 * time.Hour)
+
 	// aws-provisioner still speaks of provisionerID/workerType
 	run.WorkerPoolID = fmt.Sprintf("%s/%s", userData.ProvisionerID, userData.WorkerType)
 

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -158,7 +158,7 @@ The providerType "google" is intended for workers provisioned with worker-manage
 providers using providerType "google".  It requires
 
 	provider:
-	    providerType: google
+		providerType: google
 `
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/google"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/standalone"
+	"github.com/taskcluster/taskcluster-worker-runner/provider/static"
 	"github.com/taskcluster/taskcluster-worker-runner/runner"
 )
 
@@ -21,6 +22,7 @@ var providers map[string]providerInfo = map[string]providerInfo{
 	"standalone":      providerInfo{standalone.New, standalone.Usage},
 	"aws-provisioner": providerInfo{awsprovisioner.New, awsprovisioner.Usage},
 	"google":          providerInfo{google.New, google.Usage},
+	"static":          providerInfo{static.New, static.Usage},
 }
 
 func New(runnercfg *runner.RunnerConfig) (provider.Provider, error) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,8 +36,10 @@ func New(runnercfg *runner.RunnerConfig) (provider.Provider, error) {
 }
 
 func Usage() string {
-	rv := []string{`
-Providers configuration depends on the providerType:`}
+	rv := []string{`## Providers
+
+Providers configuration depends on the providerType:
+`}
 
 	sortedProviders := make([]string, len(providers))
 	i := 0
@@ -49,7 +51,8 @@ Providers configuration depends on the providerType:`}
 
 	for _, n := range sortedProviders {
 		info := providers[n]
-		rv = append(rv, info.usage())
+		usage := strings.Trim(info.usage(), " \n\t")
+		rv = append(rv, fmt.Sprintf("### %s\n\n%s\n", n, usage))
 	}
 	return strings.Join(rv, "\n")
 }

--- a/provider/provider/common.go
+++ b/provider/provider/common.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	"github.com/taskcluster/taskcluster/clients/client-go/v14/tcworkermanager"
+)
+
+// Register this worker with the worker-manager, and update the run with the parameters and the results.
+func RegisterWorker(run *runner.Run, wm tc.WorkerManager, workerPoolID, providerID, workerGroup, workerID, workerIdentityKey, workerIdentityValue string) error {
+	workerIdentityProofMap := map[string]interface{}{workerIdentityKey: interface{}(workerIdentityValue)}
+	workerIdentityProof, err := json.Marshal(workerIdentityProofMap)
+	if err != nil {
+		return err
+	}
+
+	reg, err := wm.RegisterWorker(&tcworkermanager.RegisterWorkerRequest{
+		WorkerPoolID:        workerPoolID,
+		ProviderID:          providerID,
+		WorkerGroup:         workerGroup,
+		WorkerID:            workerID,
+		WorkerIdentityProof: json.RawMessage(workerIdentityProof),
+	})
+	if err != nil {
+		return fmt.Errorf("Could not register worker: %v", err)
+	}
+
+	run.WorkerPoolID = workerPoolID
+	run.WorkerID = workerID
+	run.WorkerGroup = workerGroup
+
+	run.Credentials.ClientID = reg.Credentials.ClientID
+	run.Credentials.AccessToken = reg.Credentials.AccessToken
+	run.Credentials.Certificate = reg.Credentials.Certificate
+
+	run.CredentialsExpire = time.Time(reg.Expires)
+
+	return nil
+}

--- a/provider/standalone/standalone.go
+++ b/provider/standalone/standalone.go
@@ -56,8 +56,11 @@ func New(runnercfg *runner.RunnerConfig) (provider.Provider, error) {
 func Usage() string {
 	return `
 The providerType "standalone" is intended for workers that have all of their
-configuration pre-loaded.  It requires the following properties be included
-explicitly in the runner configuration:
+configuration pre-loaded.  Such workers do not interact with the worker manager.
+This is not a recommended configuration - prefer to use the static provider.
+
+It requires the following properties be included explicitly in the runner
+configuration:
 
 	provider:
 		providerType: standalone

--- a/provider/standalone/standalone.go
+++ b/provider/standalone/standalone.go
@@ -33,7 +33,7 @@ func (p *StandaloneProvider) ConfigureRun(run *runner.Run) error {
 	run.WorkerGroup = pc.WorkerGroup
 	run.WorkerID = pc.WorkerID
 
-	run.WorkerConfig = run.WorkerConfig.Merge(nil)
+	run.ProviderMetadata = map[string]string{}
 
 	return nil
 }

--- a/provider/standalone/standalone_test.go
+++ b/provider/standalone/standalone_test.go
@@ -1,0 +1,54 @@
+package standalone
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+)
+
+func TestConfigureRun(t *testing.T) {
+	runnerWorkerConfig := cfg.NewWorkerConfig()
+	runnerWorkerConfig, err := runnerWorkerConfig.Set("from-runner-cfg", true)
+	assert.NoError(t, err, "setting config")
+	runnercfg := &runner.RunnerConfig{
+		Provider: cfg.ProviderConfig{
+			ProviderType: "standalone",
+			Data: map[string]interface{}{
+				"rootURL":      "https://tc.example.com",
+				"clientID":     "testing",
+				"accessToken":  "at",
+				"workerPoolID": "w/p",
+				"workerGroup":  "wg",
+				"workerID":     "wi",
+			},
+		},
+		WorkerImplementation: cfg.WorkerImplementationConfig{
+			Implementation: "whatever",
+		},
+		WorkerConfig: runnerWorkerConfig,
+	}
+
+	p, err := New(runnercfg)
+	assert.NoError(t, err, "creating provider")
+
+	run := runner.Run{
+		WorkerConfig: runnercfg.WorkerConfig,
+	}
+	err = p.ConfigureRun(&run)
+	if !assert.NoError(t, err, "ConfigureRun") {
+		return
+	}
+
+	assert.Equal(t, "https://tc.example.com", run.RootURL, "rootURL is correct")
+	assert.Equal(t, "testing", run.Credentials.ClientID, "clientID is correct")
+	assert.Equal(t, "at", run.Credentials.AccessToken, "accessToken is correct")
+	assert.Equal(t, "", run.Credentials.Certificate, "cert is correct")
+	assert.Equal(t, "w/p", run.WorkerPoolID, "workerPoolID is correct")
+	assert.Equal(t, "wg", run.WorkerGroup, "workerGroup is correct")
+	assert.Equal(t, "wi", run.WorkerID, "workerID is correct")
+	assert.Equal(t, map[string]string{}, run.ProviderMetadata, "providerMetadata is correct")
+
+	assert.Equal(t, true, run.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
+}

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -12,12 +12,12 @@ import (
 )
 
 type staticProviderConfig struct {
-	RootURL        string
-	ProviderID     string
-	WorkerPoolID   string
-	WorkerGroup    string
-	WorkerID       string
-	IdentitySecret string
+	RootURL      string
+	ProviderID   string
+	WorkerPoolID string
+	WorkerGroup  string
+	WorkerID     string
+	StaticSecret string
 }
 
 type StaticProvider struct {
@@ -42,7 +42,7 @@ func (p *StaticProvider) ConfigureRun(run *runner.Run) error {
 		return fmt.Errorf("Could not create worker manager client: %v", err)
 	}
 
-	err = provider.RegisterWorker(run, wm, pc.WorkerPoolID, pc.ProviderID, pc.WorkerGroup, pc.WorkerID, "secret", pc.IdentitySecret)
+	err = provider.RegisterWorker(run, wm, pc.WorkerPoolID, pc.ProviderID, pc.WorkerGroup, pc.WorkerID, "staticSecret", pc.StaticSecret)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ providers using providerType "static".  It requires
 		workerPoolID: ...
 		workerGroup: ...
 		workerID: ...
-		identitySecret: ... // shared secret configured for this worker in worker-manager
+		staticSecret: ... // shared secret configured for this worker in worker-manager
 `
 }
 

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -1,0 +1,147 @@
+package static
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v14"
+	"github.com/taskcluster/taskcluster/clients/client-go/v14/tcworkermanager"
+)
+
+type staticProviderConfig struct {
+	RootURL        string
+	ProviderID     string
+	WorkerPoolID   string
+	WorkerGroup    string
+	WorkerID       string
+	IdentitySecret string
+}
+
+type StaticProvider struct {
+	runnercfg                  *runner.RunnerConfig
+	workerManagerClientFactory tc.WorkerManagerClientFactory
+	proto                      *protocol.Protocol
+
+	credsExpire      tcclient.Time
+	credsExpireTimer *time.Timer
+}
+
+func (p *StaticProvider) ConfigureRun(run *runner.Run) error {
+	var pc staticProviderConfig
+	err := p.runnercfg.Provider.Unpack(&pc)
+	if err != nil {
+		return err
+	}
+
+	run.RootURL = pc.RootURL
+	run.WorkerPoolID = pc.WorkerPoolID
+	run.WorkerGroup = pc.WorkerGroup
+	run.WorkerID = pc.WorkerID
+
+	workerIdentityProofMap := map[string]interface{}{"secret": interface{}(pc.IdentitySecret)}
+	workerIdentityProof, err := json.Marshal(workerIdentityProofMap)
+	if err != nil {
+		return err
+	}
+
+	// We need a worker manager client for fetching taskcluster credentials.
+	// Ensure auth is disabled in client, since we don't have credentials yet.
+	wm, err := p.workerManagerClientFactory(run.RootURL, nil)
+	if err != nil {
+		return fmt.Errorf("Could not create worker manager client: %v", err)
+	}
+
+	reg, err := wm.RegisterWorker(&tcworkermanager.RegisterWorkerRequest{
+		WorkerPoolID:        pc.WorkerPoolID,
+		ProviderID:          pc.ProviderID,
+		WorkerGroup:         pc.WorkerGroup,
+		WorkerID:            pc.WorkerID,
+		WorkerIdentityProof: json.RawMessage(workerIdentityProof),
+	})
+	if err != nil {
+		return fmt.Errorf("Could not register worker: %v", err)
+	}
+
+	run.Credentials.ClientID = reg.Credentials.ClientID
+	run.Credentials.AccessToken = reg.Credentials.AccessToken
+	run.Credentials.Certificate = reg.Credentials.Certificate
+
+	p.credsExpire = reg.Expires
+
+	run.ProviderMetadata = map[string]string{}
+
+	return nil
+}
+
+func (p *StaticProvider) SetProtocol(proto *protocol.Protocol) {
+	p.proto = proto
+}
+
+func (p *StaticProvider) WorkerStarted() error {
+	// gracefully terminate the worker when the credentials expire
+	untilExpire := time.Until(time.Time(p.credsExpire))
+	p.credsExpireTimer = time.AfterFunc(untilExpire-30*time.Second, func() {
+		if p.proto != nil && p.proto.Capable("graceful-termination") {
+			log.Println("Taskcluster Credentials are expiring in 30s; stopping worker")
+			p.proto.Send(protocol.Message{
+				Type: "graceful-termination",
+				Properties: map[string]interface{}{
+					// credentials are expiring, so no time to shut down..
+					"finish-tasks": false,
+				},
+			})
+		}
+	})
+	return nil
+}
+
+func (p *StaticProvider) WorkerFinished() error {
+	if p.credsExpireTimer != nil {
+		p.credsExpireTimer.Stop()
+		p.credsExpireTimer = nil
+	}
+	return nil
+}
+
+func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {
+	prov := tcworkermanager.New(credentials, rootURL)
+	return prov, nil
+}
+
+func New(runnercfg *runner.RunnerConfig) (provider.Provider, error) {
+	return new(runnercfg, nil)
+}
+
+func Usage() string {
+	return `
+The providerType "static" is intended for workers provisioned with worker-manager
+providers using providerType "static".  It requires
+
+	provider:
+		providerType: static
+		rootURL: ...
+		providerID: ...
+		workerPoolID: ...
+		workerGroup: ...
+		workerID: ...
+		identitySecret: ... // shared secret configured for this worker in worker-manager
+`
+}
+
+// New takes its dependencies as optional arguments, allowing injection of fake dependencies for testing.
+func new(runnercfg *runner.RunnerConfig, workerManagerClientFactory tc.WorkerManagerClientFactory) (*StaticProvider, error) {
+	if workerManagerClientFactory == nil {
+		workerManagerClientFactory = clientFactory
+	}
+	return &StaticProvider{
+		runnercfg:                  runnercfg,
+		workerManagerClientFactory: workerManagerClientFactory,
+		proto:                      nil,
+	}, nil
+}

--- a/provider/static/static_test.go
+++ b/provider/static/static_test.go
@@ -3,14 +3,11 @@ package static
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
-	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/runner"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v14"
 )
 
 func TestConfigureRun(t *testing.T) {
@@ -65,59 +62,4 @@ func TestConfigureRun(t *testing.T) {
 	assert.Equal(t, map[string]string{}, run.ProviderMetadata, "providerMetadata is correct")
 
 	assert.Equal(t, true, run.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
-}
-
-func TestCredsExpiration(t *testing.T) {
-	runnercfg := &runner.RunnerConfig{
-		Provider: cfg.ProviderConfig{
-			ProviderType: "static",
-			Data: map[string]interface{}{
-				"rootURL":        "https://tc.example.com",
-				"providerID":     "static-1",
-				"workerPoolID":   "w/p",
-				"workerGroup":    "wg",
-				"workerID":       "wi",
-				"identitySecret": "quiet",
-			},
-		},
-		WorkerImplementation: cfg.WorkerImplementationConfig{
-			Implementation: "whatever",
-		},
-		WorkerConfig: cfg.NewWorkerConfig(),
-	}
-
-	p, err := new(runnercfg, tc.FakeWorkerManagerClientFactory)
-	assert.NoError(t, err, "creating provider")
-
-	transp := protocol.NewFakeTransport()
-	p.proto = protocol.NewProtocol(transp)
-	p.proto.Capabilities.Add("graceful-termination")
-
-	// send the shutdown message right now
-	p.credsExpire = tcclient.Time(time.Now().Add(30 * time.Second))
-	err = p.WorkerStarted()
-	assert.NoError(t, err)
-
-	// and wait until that happens
-	for {
-		time.Sleep(10 * time.Millisecond)
-
-		haveMessage := len(transp.Messages()) != 0
-
-		if haveMessage {
-			break
-		}
-	}
-
-	assert.Equal(t, []protocol.Message{
-		protocol.Message{
-			Type: "graceful-termination",
-			Properties: map[string]interface{}{
-				"finish-tasks": false,
-			},
-		},
-	}, transp.Messages())
-
-	err = p.WorkerFinished()
-	assert.NoError(t, err)
 }

--- a/provider/static/static_test.go
+++ b/provider/static/static_test.go
@@ -18,12 +18,12 @@ func TestConfigureRun(t *testing.T) {
 		Provider: cfg.ProviderConfig{
 			ProviderType: "static",
 			Data: map[string]interface{}{
-				"rootURL":        "https://tc.example.com",
-				"providerID":     "static-1",
-				"workerPoolID":   "w/p",
-				"workerGroup":    "wg",
-				"workerID":       "wi",
-				"identitySecret": "quiet",
+				"rootURL":      "https://tc.example.com",
+				"providerID":   "static-1",
+				"workerPoolID": "w/p",
+				"workerGroup":  "wg",
+				"workerID":     "wi",
+				"staticSecret": "quiet",
 			},
 		},
 		WorkerImplementation: cfg.WorkerImplementationConfig{
@@ -48,7 +48,7 @@ func TestConfigureRun(t *testing.T) {
 		assert.Equal(t, "static-1", reg.ProviderID)
 		assert.Equal(t, "wg", reg.WorkerGroup)
 		assert.Equal(t, "wi", reg.WorkerID)
-		assert.Equal(t, json.RawMessage(`{"secret":"quiet"}`), reg.WorkerIdentityProof)
+		assert.Equal(t, json.RawMessage(`{"staticSecret":"quiet"}`), reg.WorkerIdentityProof)
 		assert.Equal(t, "w/p", reg.WorkerPoolID)
 	}
 

--- a/provider/static/static_test.go
+++ b/provider/static/static_test.go
@@ -1,0 +1,123 @@
+package static
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	"github.com/taskcluster/taskcluster-worker-runner/runner"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v14"
+)
+
+func TestConfigureRun(t *testing.T) {
+	runnerWorkerConfig := cfg.NewWorkerConfig()
+	runnerWorkerConfig, err := runnerWorkerConfig.Set("from-runner-cfg", true)
+	assert.NoError(t, err, "setting config")
+	runnercfg := &runner.RunnerConfig{
+		Provider: cfg.ProviderConfig{
+			ProviderType: "static",
+			Data: map[string]interface{}{
+				"rootURL":        "https://tc.example.com",
+				"providerID":     "static-1",
+				"workerPoolID":   "w/p",
+				"workerGroup":    "wg",
+				"workerID":       "wi",
+				"identitySecret": "quiet",
+			},
+		},
+		WorkerImplementation: cfg.WorkerImplementationConfig{
+			Implementation: "whatever",
+		},
+		WorkerConfig: runnerWorkerConfig,
+	}
+
+	p, err := new(runnercfg, tc.FakeWorkerManagerClientFactory)
+	assert.NoError(t, err, "creating provider")
+
+	run := runner.Run{
+		WorkerConfig: runnercfg.WorkerConfig,
+	}
+	err = p.ConfigureRun(&run)
+	if !assert.NoError(t, err, "ConfigureRun") {
+		return
+	}
+
+	reg, err := tc.FakeWorkerManagerRegistration()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "static-1", reg.ProviderID)
+		assert.Equal(t, "wg", reg.WorkerGroup)
+		assert.Equal(t, "wi", reg.WorkerID)
+		assert.Equal(t, json.RawMessage(`{"secret":"quiet"}`), reg.WorkerIdentityProof)
+		assert.Equal(t, "w/p", reg.WorkerPoolID)
+	}
+
+	assert.Equal(t, "https://tc.example.com", run.RootURL, "rootURL is correct")
+	assert.Equal(t, "testing", run.Credentials.ClientID, "clientID is correct")
+	assert.Equal(t, "at", run.Credentials.AccessToken, "accessToken is correct")
+	assert.Equal(t, "cert", run.Credentials.Certificate, "cert is correct")
+	assert.Equal(t, "w/p", run.WorkerPoolID, "workerPoolID is correct")
+	assert.Equal(t, "wg", run.WorkerGroup, "workerGroup is correct")
+	assert.Equal(t, "wi", run.WorkerID, "workerID is correct")
+	assert.Equal(t, map[string]string{}, run.ProviderMetadata, "providerMetadata is correct")
+
+	assert.Equal(t, true, run.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
+}
+
+func TestCredsExpiration(t *testing.T) {
+	runnercfg := &runner.RunnerConfig{
+		Provider: cfg.ProviderConfig{
+			ProviderType: "static",
+			Data: map[string]interface{}{
+				"rootURL":        "https://tc.example.com",
+				"providerID":     "static-1",
+				"workerPoolID":   "w/p",
+				"workerGroup":    "wg",
+				"workerID":       "wi",
+				"identitySecret": "quiet",
+			},
+		},
+		WorkerImplementation: cfg.WorkerImplementationConfig{
+			Implementation: "whatever",
+		},
+		WorkerConfig: cfg.NewWorkerConfig(),
+	}
+
+	p, err := new(runnercfg, tc.FakeWorkerManagerClientFactory)
+	assert.NoError(t, err, "creating provider")
+
+	transp := protocol.NewFakeTransport()
+	p.proto = protocol.NewProtocol(transp)
+	p.proto.Capabilities.Add("graceful-termination")
+
+	// send the shutdown message right now
+	p.credsExpire = tcclient.Time(time.Now().Add(30 * time.Second))
+	err = p.WorkerStarted()
+	assert.NoError(t, err)
+
+	// and wait until that happens
+	for {
+		time.Sleep(10 * time.Millisecond)
+
+		haveMessage := len(transp.Messages()) != 0
+
+		if haveMessage {
+			break
+		}
+	}
+
+	assert.Equal(t, []protocol.Message{
+		protocol.Message{
+			Type: "graceful-termination",
+			Properties: map[string]interface{}{
+				"finish-tasks": false,
+			},
+		},
+	}, transp.Messages())
+
+	err = p.WorkerFinished()
+	assert.NoError(t, err)
+}

--- a/runner/config.go
+++ b/runner/config.go
@@ -18,7 +18,9 @@ type RunnerConfig struct {
 // Get a fragment of a usage message that describes the configuration file format
 func Usage() string {
 	return `
-Configuration is in the form of a YAML file with the following fields:
+## Configuration
+
+Configuration for this process is in the form of a YAML file with the following fields:
 
 	provider: (required) information about the provider for this worker
 
@@ -28,7 +30,7 @@ Configuration is in the form of a YAML file with the following fields:
 
 	worker: (required) information about the worker being run
 
-		implementation: (required) the name of the worker implementation
+		implementation: (required) the name of the worker implementation; see below.
 
 	workerConfig: arbitrary data which forms the basics of the config passed to the worker;
 		this will be merged with several other sources of configuration.

--- a/runner/run.go
+++ b/runner/run.go
@@ -1,8 +1,12 @@
 package runner
 
 import (
-	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v14"
+	"log"
+	"time"
+
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v14"
 )
 
 // Run represents all of the information required to run the worker.  Its
@@ -10,8 +14,12 @@ import (
 type Run struct {
 	// Information about the Taskcluster deployment where this
 	// worker is runing
-	RootURL     string
-	Credentials taskcluster.Credentials
+	RootURL string
+
+	// Credentials for the worker, and their expiration time.  Shortly before
+	// this expiration, worker-runner will try to gracefully stop the worker
+	Credentials       taskcluster.Credentials
+	CredentialsExpire time.Time
 
 	// Information about this worker
 	WorkerPoolID string
@@ -26,4 +34,45 @@ type Run struct {
 
 	// the accumulated WorkerConfig for this run
 	WorkerConfig *cfg.WorkerConfig
+
+	// the protocol (set in SetProtocol)
+	proto *protocol.Protocol
+
+	// a timer to handle sending a graceful-termination request before
+	// the credentials expire
+	credsExpireTimer *time.Timer
+}
+
+func (r *Run) SetProtocol(proto *protocol.Protocol) {
+	r.proto = proto
+}
+
+func (r *Run) WorkerStarted() error {
+	// gracefully terminate the worker when the credentials expire, if they expire
+	if r.CredentialsExpire.IsZero() {
+		return nil
+	}
+
+	untilExpire := time.Until(r.CredentialsExpire)
+	r.credsExpireTimer = time.AfterFunc(untilExpire-30*time.Second, func() {
+		if r.proto != nil && r.proto.Capable("graceful-termination") {
+			log.Println("Taskcluster Credentials are expiring in 30s; stopping worker")
+			r.proto.Send(protocol.Message{
+				Type: "graceful-termination",
+				Properties: map[string]interface{}{
+					// credentials are expiring, so no time to shut down..
+					"finish-tasks": false,
+				},
+			})
+		}
+	})
+	return nil
+}
+
+func (r *Run) WorkerFinished() error {
+	if r.credsExpireTimer != nil {
+		r.credsExpireTimer.Stop()
+		r.credsExpireTimer = nil
+	}
+	return nil
 }

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+)
+
+func TestCredsExpiration(t *testing.T) {
+	run := &Run{
+		// message is sent 30 seconds before expiration, so set expiration
+		// for 30s from now
+		CredentialsExpire: time.Now().Add(30 * time.Second),
+	}
+
+	transp := protocol.NewFakeTransport()
+	run.proto = protocol.NewProtocol(transp)
+	run.proto.Capabilities.Add("graceful-termination")
+
+	err := run.WorkerStarted()
+	assert.NoError(t, err)
+
+	// and wait until that happens
+	for {
+		time.Sleep(10 * time.Millisecond)
+		haveMessage := len(transp.Messages()) != 0
+		if haveMessage {
+			break
+		}
+	}
+
+	assert.Equal(t, []protocol.Message{
+		protocol.Message{
+			Type: "graceful-termination",
+			Properties: map[string]interface{}{
+				"finish-tasks": false,
+			},
+		},
+	}, transp.Messages())
+
+	err = run.WorkerFinished()
+	assert.NoError(t, err)
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,8 +34,10 @@ func New(runnercfg *runner.RunnerConfig) (worker.Worker, error) {
 }
 
 func Usage() string {
-	rv := []string{`
-The following worker implementations are supported:`}
+	rv := []string{`## Workers
+
+The following worker implementations are supported:
+`}
 
 	sortedWorkers := make([]string, len(workers))
 	i := 0
@@ -47,7 +49,8 @@ The following worker implementations are supported:`}
 
 	for _, n := range sortedWorkers {
 		info := workers[n]
-		rv = append(rv, info.usage())
+		usage := strings.Trim(info.usage(), " \n\t")
+		rv = append(rv, fmt.Sprintf("### %s\n\n%s\n", n, usage))
 	}
 	return strings.Join(rv, "\n")
 }


### PR DESCRIPTION
This assumes some things about the to-be-written worker-manager provider.  Really, it assumes that it accepts a `workerIdentityProof` of the form `{"secret": ".."}`.