### PR TITLE
Pass through custom aws userdata data

### DIFF
--- a/provider/awsprovisioner/metadata.go
+++ b/provider/awsprovisioner/metadata.go
@@ -9,6 +9,15 @@ import (
 )
 
 var EC2MetadataBaseURL = "http://169.254.169.254/latest"
+var userDataPredefinedFields = []string{
+	"data",
+	"workerType",
+	"provisionerId",
+	"region",
+	"taskclusterRootUrl",
+	"securityToken",
+	"capacity",
+}
 
 type userDataData struct {
 	Config *cfg.WorkerConfig `json:"config"`
@@ -42,7 +51,33 @@ func (mds *realMetadataService) queryUserData() (*UserData, error) {
 		return nil, err
 	}
 	userData := &UserData{}
-	err = json.Unmarshal([]byte(content), userData)
+	if err = json.Unmarshal([]byte(content), userData); err != nil {
+		return nil, err
+	}
+
+	if userData.Data.Config == nil {
+		userData.Data.Config = cfg.NewWorkerConfig()
+	}
+
+	customData := make(map[string]interface{})
+	if err = json.Unmarshal([]byte(content), &customData); err != nil {
+		return nil, err
+	}
+
+	// docker-worker expects any custom user data config to be passed directly to it
+out:
+	for k, v := range customData {
+		// Do not add pre-defined fields
+		for _, d := range userDataPredefinedFields {
+			if k == d {
+				continue out
+			}
+		}
+		if userData.Data.Config, err = userData.Data.Config.Set(k, v); err != nil {
+			return nil, err
+		}
+	}
+
 	return userData, err
 }
 

--- a/provider/awsprovisioner/metadata_test.go
+++ b/provider/awsprovisioner/metadata_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/require"
 	"github.com/taskcluster/httpbackoff"
 )
 
@@ -58,7 +58,7 @@ func TestQueryMetadata(t *testing.T) {
 	assert.Equal(t, "42\n", rv)
 
 	_, err = ms.queryMetadata("/meta-data/NOSUCH")
-	if assert.Error(t, err) {
+	if err != nil {
 		httperr, ok := err.(httpbackoff.BadHttpResponseCode)
 		assert.True(t, ok)
 		assert.Equal(t, 404, httperr.HttpResponseCode)
@@ -69,7 +69,7 @@ func TestQueryUserData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/latest/user-data" {
 			w.WriteHeader(200)
-			fmt.Fprintln(w, `{"region": "aa-central-2"}`)
+			fmt.Fprintln(w, `{"region": "aa-central-2", "custom": "custom-data", "dockerConfig": {"privileged": true}}`)
 		} else {
 			w.WriteHeader(404)
 			fmt.Fprintf(w, "Not Found: %s", r.URL.Path)
@@ -87,4 +87,14 @@ func TestQueryUserData(t *testing.T) {
 	ud, err := ms.queryUserData()
 	assert.NoError(t, err)
 	assert.Equal(t, "aa-central-2", ud.Region)
+	assert.NotNil(t, ud.Data)
+	assert.NotNil(t, ud.Data.Config)
+	customData, err := ud.Data.Config.Get("custom")
+	assert.NoError(t, err)
+	assert.Equal(t, "custom-data", customData)
+	privileged, err := ud.Data.Config.Get("dockerConfig.privileged")
+	assert.NoError(t, err)
+	assert.Equal(t, privileged, true)
+	_, err = ud.Data.Config.Get("region")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
many worker types configurations set custom docker-worker configuration
data. We then pass through any user data we don't recognize.

closes #22