### PR TITLE
Fixes custom user data configuration

### DIFF
--- a/provider/awsprovisioner/awsprovisioner.go
+++ b/provider/awsprovisioner/awsprovisioner.go
@@ -62,7 +62,7 @@ func (p *AwsProvisionerProvider) ConfigureRun(state *run.State) error {
 
 	state.WorkerGroup = userData.Region
 
-	state.WorkerConfig = state.WorkerConfig.Merge(userData.Data.Config)
+	state.WorkerConfig = state.WorkerConfig.Merge(userData.Data)
 
 	// aws-provisioner includes capacity in the userdata, but we would like to reflect
 	// that as worker config instead.  For compatibility, we just do this when it is

--- a/provider/awsprovisioner/awsprovisioner_test.go
+++ b/provider/awsprovisioner/awsprovisioner_test.go
@@ -40,9 +40,7 @@ func TestAwsProviderConfigureRun(t *testing.T) {
 	userDataWorkerConfig, err = userDataWorkerConfig.Set("from-user-data", true)
 	assert.NoError(t, err, "setting config")
 	userData := &UserData{
-		Data: userDataData{
-			Config: userDataWorkerConfig,
-		},
+		Data:               userDataWorkerConfig,
 		WorkerType:         "wt",
 		ProvisionerID:      "apv1",
 		Region:             "rgn",

--- a/provider/awsprovisioner/metadata.go
+++ b/provider/awsprovisioner/metadata.go
@@ -10,19 +10,15 @@ import (
 
 var EC2MetadataBaseURL = "http://169.254.169.254/latest"
 
-type userDataData struct {
-	Config *cfg.WorkerConfig `json:"config"`
-}
-
 // taken from https://github.com/taskcluster/aws-provisioner/blob/5a2bc7c57b20df00f9c4357e0daeb7967e6f5ee8/lib/worker-type.js#L607-L624
 type UserData struct {
-	Data               userDataData `json:"data"`
-	WorkerType         string       `json:"workerType"`
-	ProvisionerID      string       `json:"provisionerId"`
-	Region             string       `json:"region"`
-	TaskclusterRootURL string       `json:"taskclusterRootUrl"`
-	SecurityToken      string       `json:"securityToken"`
-	Capacity           int          `json:"capacity"`
+	Data               *cfg.WorkerConfig `json:"data"`
+	WorkerType         string            `json:"workerType"`
+	ProvisionerID      string            `json:"provisionerId"`
+	Region             string            `json:"region"`
+	TaskclusterRootURL string            `json:"taskclusterRootUrl"`
+	SecurityToken      string            `json:"securityToken"`
+	Capacity           int               `json:"capacity"`
 }
 
 type MetadataService interface {


### PR DESCRIPTION
docker-worker expects custom user data comes in the form:

```json
{
  "data": {
  }
}
```

But taskcluster-worker-runner passes it as:

```json
{
  "data": {
    "config": {
    }
  }
}
```

closes #22