### PR TITLE
Aws provider

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/taskcluster/httpbackoff v1.0.0 h1:bdh5txPv6geBVSEcx7Jy3kqiBaIrCZJwzCotPJKf9DU=
 github.com/taskcluster/httpbackoff v1.0.0/go.mod h1:DEx05B3r52XQRbgzZ5y6XorMjVXBhtoHgc/ap+yLXgY=

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -1,22 +1,22 @@
 package awsprovider
 
-import(
+import (
 	"fmt"
 
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
-	"github.com/taskcluster/taskcluster-worker-runner/tc"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
-	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
+	"github.com/taskcluster/taskcluster-worker-runner/run"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
 	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v15"
 	"github.com/taskcluster/taskcluster/clients/client-go/v15/tcworkermanager"
-	)
+)
 
 type AWSProvider struct {
-	runnercfg *cfg.RunnerConfig
+	runnercfg                  *cfg.RunnerConfig
 	workerManagerClientFactory tc.WorkerManagerClientFactory
-	metadataService MetadataService
-	proto *protocol.Protocol
+	metadataService            MetadataService
+	proto                      *protocol.Protocol
 }
 
 func (p *AWSProvider) ConfigureRun(state *run.State) error {
@@ -43,7 +43,7 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 	}
 
 	workerIdentityProofMap := map[string]interface{}{
-		"document": interface{}(instanceIdentityDocument_string),
+		"document":  interface{}(instanceIdentityDocument_string),
 		"signature": interface{}(instanceIdentityDocumentSignature),
 	}
 
@@ -70,14 +70,14 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 	}
 
 	providerMetadata := map[string]string{
-		"instance-id": instanceIdentityDocument_json.InstanceId,
-		"image": instanceIdentityDocument_json.ImageId,
-		"instance-type": instanceIdentityDocument_json.InstanceType,
-		"region": instanceIdentityDocument_json.Region,
+		"instance-id":       instanceIdentityDocument_json.InstanceId,
+		"image":             instanceIdentityDocument_json.ImageId,
+		"instance-type":     instanceIdentityDocument_json.InstanceType,
+		"region":            instanceIdentityDocument_json.Region,
 		"availability-zone": instanceIdentityDocument_json.AvailabilityZone,
-		"local-ipv4": instanceIdentityDocument_json.PrivateIp,
-		"public-hostname": publicHostname,
-		"public-ipv4": publicIp,
+		"local-ipv4":        instanceIdentityDocument_json.PrivateIp,
+		"public-hostname":   publicHostname,
+		"public-ipv4":       publicIp,
 	}
 
 	state.ProviderMetadata = providerMetadata
@@ -124,7 +124,7 @@ providers using providerType "aws".  It requires
 func new(
 	runnercfg *cfg.RunnerConfig,
 	workerManagerClientFactory tc.WorkerManagerClientFactory,
-	metadataService MetadataService)(*AWSProvider, error) {
+	metadataService MetadataService) (*AWSProvider, error) {
 
 	if workerManagerClientFactory == nil {
 		workerManagerClientFactory = clientFactory
@@ -135,9 +135,9 @@ func new(
 	}
 
 	return &AWSProvider{
-		runnercfg: runnercfg,
+		runnercfg:                  runnercfg,
 		workerManagerClientFactory: workerManagerClientFactory,
-		metadataService: metadataService,
-		proto: nil,
+		metadataService:            metadataService,
+		proto:                      nil,
 	}, nil
 }

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -59,6 +59,16 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
+	providerMetadata := map[string]string{
+		"instance-id": instanceIdentityDocument_json.InstanceId,
+		"image": instanceIdentityDocument_json.ImageId,
+		"instance-type": instanceIdentityDocument_json.InstanceType,
+		"region": instanceIdentityDocument_json.Region,
+		"availability-zone": instanceIdentityDocument_json.AvailabilityZone,
+	}
+
+	state.ProviderMetadata = providerMetadata
+
 	return nil
 }
 

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -1,0 +1,120 @@
+package awsprovider
+
+import(
+	"fmt"
+
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	"github.com/taskcluster/taskcluster-worker-runner/protocol"
+	"github.com/taskcluster/taskcluster-worker-runner/run"
+	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v15"
+	"github.com/taskcluster/taskcluster/clients/client-go/v15/tcworkermanager"
+	)
+
+type AWSProvider struct {
+	runnercfg *cfg.RunnerConfig
+	workerManagerClientFactory tc.WorkerManagerClientFactory
+	metadataService MetadataService
+	proto *protocol.Protocol
+}
+
+func (p *AWSProvider) ConfigureRun(state *run.State) error {
+	userData, err := p.metadataService.queryUserData()
+	if err != nil {
+		return fmt.Errorf("Could not query user data: %v", err)
+	}
+
+	instanceIdentityDocument_string, instanceIdentityDocument_json, err := p.metadataService.queryInstanceIdentityDocument()
+	if err != nil {
+		return fmt.Errorf("Could not query instance identity document: %v", err)
+	}
+
+	instanceIdentityDocumentSignature, err := p.metadataService.queryMetadata("/dynamic/instance-identity/signature")
+	if err != nil {
+		return fmt.Errorf("Could not query signature for the instance identity document: %v", err)
+	}
+
+	state.RootURL = userData.RootURL
+
+	wm, err := p.workerManagerClientFactory(state.RootURL, nil)
+	if err != nil {
+		return fmt.Errorf("Could not create worker manager client: %v", err)
+	}
+
+	workerIdentityProofMap := map[string]interface{}{
+		"document": interface{}(instanceIdentityDocument_string),
+		"signature": interface{}(instanceIdentityDocumentSignature),
+	}
+
+	err = provider.RegisterWorker(
+		state,
+		wm,
+		userData.WorkerPoolId,
+		userData.ProviderId,
+		userData.WorkerGroup,
+		instanceIdentityDocument_json.InstanceId,
+		workerIdentityProofMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *AWSProvider) UseCachedRun(run *run.State) error {
+	return nil
+}
+
+func (p *AWSProvider) SetProtocol(proto *protocol.Protocol) {
+	p.proto = proto
+}
+
+func (p *AWSProvider) WorkerStarted() error {
+	return nil
+}
+
+func (p *AWSProvider) WorkerFinished() error {
+	return nil
+}
+
+func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {
+	prov := tcworkermanager.New(credentials, rootURL)
+	return prov, nil
+}
+
+func New(runnercfg *cfg.RunnerConfig) (provider.Provider, error) {
+	return new(runnercfg, nil, nil)
+}
+
+func Usage() string {
+	return `
+The providerType "aws" is intended for workers provisioned with worker-manager
+providers using providerType "aws".  It requires
+
+	provider:
+		providerType: aws
+`
+}
+
+// New takes its dependencies as optional arguments, allowing injection of fake dependencies for testing.
+func new(
+	runnercfg *cfg.RunnerConfig,
+	workerManagerClientFactory tc.WorkerManagerClientFactory,
+	metadataService MetadataService)(*AWSProvider, error) {
+
+	if workerManagerClientFactory == nil {
+		workerManagerClientFactory = clientFactory
+	}
+
+	if metadataService == nil {
+		metadataService = &realMetadataService{}
+	}
+
+	return &AWSProvider{
+		runnercfg: runnercfg,
+		workerManagerClientFactory: workerManagerClientFactory,
+		metadataService: metadataService,
+		proto: nil,
+	}, nil
+}

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -59,12 +59,25 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
+	publicHostname, err := p.metadataService.queryMetadata("/meta-data/public-hostname")
+	if err != nil {
+		return err
+	}
+
+	publicIp, err := p.metadataService.queryMetadata("/meta-data/public-ipv4")
+	if err != nil {
+		return err
+	}
+
 	providerMetadata := map[string]string{
 		"instance-id": instanceIdentityDocument_json.InstanceId,
 		"image": instanceIdentityDocument_json.ImageId,
 		"instance-type": instanceIdentityDocument_json.InstanceType,
 		"region": instanceIdentityDocument_json.Region,
 		"availability-zone": instanceIdentityDocument_json.AvailabilityZone,
+		"local-ipv4": instanceIdentityDocument_json.PrivateIp,
+		"public-hostname": publicHostname,
+		"public-ipv4": publicIp,
 	}
 
 	state.ProviderMetadata = providerMetadata

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -25,7 +25,7 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 		return fmt.Errorf("Could not query user data: %v", err)
 	}
 
-	instanceIdentityDocument_string, instanceIdentityDocument_json, err := p.metadataService.queryInstanceIdentityDocument()
+	iid_string, iid_json, err := p.metadataService.queryInstanceIdentityDocument()
 	if err != nil {
 		return fmt.Errorf("Could not query instance identity document: %v", err)
 	}
@@ -43,7 +43,7 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 	}
 
 	workerIdentityProofMap := map[string]interface{}{
-		"document":  interface{}(instanceIdentityDocument_string),
+		"document":  interface{}(iid_string),
 		"signature": interface{}(instanceIdentityDocumentSignature),
 	}
 
@@ -53,7 +53,7 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 		userData.WorkerPoolId,
 		userData.ProviderId,
 		userData.WorkerGroup,
-		instanceIdentityDocument_json.InstanceId,
+		iid_json.InstanceId,
 		workerIdentityProofMap)
 	if err != nil {
 		return err
@@ -70,12 +70,12 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 	}
 
 	providerMetadata := map[string]string{
-		"instance-id":       instanceIdentityDocument_json.InstanceId,
-		"image":             instanceIdentityDocument_json.ImageId,
-		"instance-type":     instanceIdentityDocument_json.InstanceType,
-		"region":            instanceIdentityDocument_json.Region,
-		"availability-zone": instanceIdentityDocument_json.AvailabilityZone,
-		"local-ipv4":        instanceIdentityDocument_json.PrivateIp,
+		"instance-id":       iid_json.InstanceId,
+		"image":             iid_json.ImageId,
+		"instance-type":     iid_json.InstanceType,
+		"region":            iid_json.Region,
+		"availability-zone": iid_json.AvailabilityZone,
+		"local-ipv4":        iid_json.PrivateIp,
 		"public-hostname":   publicHostname,
 		"public-ipv4":       publicIp,
 	}

--- a/provider/awsprovider/awsprovider_test.go
+++ b/provider/awsprovider/awsprovider_test.go
@@ -33,9 +33,11 @@ func TestAWSConfigureRun(t *testing.T) {
 
 	metaData := map[string]string{
 		"/dynamic/instance-identity/signature": "thisisasignature",
+		"/meta-data/public-hostname": "hostname",
+		"/meta-data/public-ipv4": "2.2.2.2",
 	}
 
-	instanceIdentityDocument := "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}"
+	instanceIdentityDocument := "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}"
 
 
 	mds := &fakeMetadataService{nil, userData, metaData, instanceIdentityDocument}
@@ -56,7 +58,7 @@ func TestAWSConfigureRun(t *testing.T) {
 		assert.Equal(t, userData.ProviderId, reg.ProviderID)
 		assert.Equal(t, userData.WorkerGroup, reg.WorkerGroup)
 		assert.Equal(t, "i-55555nonesense5", reg.WorkerID)
-		assert.Equal(t, json.RawMessage(`{"document":"{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}","signature":"thisisasignature"}`), reg.WorkerIdentityProof)
+		assert.Equal(t, json.RawMessage(`{"document":"{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}","signature":"thisisasignature"}`), reg.WorkerIdentityProof)
 		assert.Equal(t, "w/p", reg.WorkerPoolID)
 	}
 
@@ -74,6 +76,9 @@ func TestAWSConfigureRun(t *testing.T) {
 		"instance-type": "t2.micro",
 		"availability-zone": "us-west-2a",
 		"region": "us-west-2",
+		"local-ipv4": "1.1.1.1",
+		"public-hostname": "hostname",
+		"public-ipv4": "2.2.2.2",
 	}, state.ProviderMetadata, "providerMetadata is correct")
 
 	assert.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")

--- a/provider/awsprovider/awsprovider_test.go
+++ b/provider/awsprovider/awsprovider_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/stretchr/testify/assert"
-	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
 )
 
 func TestAWSConfigureRun(t *testing.T) {
@@ -33,12 +33,11 @@ func TestAWSConfigureRun(t *testing.T) {
 
 	metaData := map[string]string{
 		"/dynamic/instance-identity/signature": "thisisasignature",
-		"/meta-data/public-hostname": "hostname",
-		"/meta-data/public-ipv4": "2.2.2.2",
+		"/meta-data/public-hostname":           "hostname",
+		"/meta-data/public-ipv4":               "2.2.2.2",
 	}
 
 	instanceIdentityDocument := "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}"
-
 
 	mds := &fakeMetadataService{nil, userData, metaData, instanceIdentityDocument}
 
@@ -71,14 +70,14 @@ func TestAWSConfigureRun(t *testing.T) {
 	assert.Equal(t, "i-55555nonesense5", state.WorkerID, "workerID is correct")
 
 	assert.Equal(t, map[string]string{
-		"instance-id": "i-55555nonesense5",
-		"image": "banana",
-		"instance-type": "t2.micro",
+		"instance-id":       "i-55555nonesense5",
+		"image":             "banana",
+		"instance-type":     "t2.micro",
 		"availability-zone": "us-west-2a",
-		"region": "us-west-2",
-		"local-ipv4": "1.1.1.1",
-		"public-hostname": "hostname",
-		"public-ipv4": "2.2.2.2",
+		"region":            "us-west-2",
+		"local-ipv4":        "1.1.1.1",
+		"public-hostname":   "hostname",
+		"public-ipv4":       "2.2.2.2",
 	}, state.ProviderMetadata, "providerMetadata is correct")
 
 	assert.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")

--- a/provider/awsprovider/awsprovider_test.go
+++ b/provider/awsprovider/awsprovider_test.go
@@ -1,0 +1,80 @@
+package awsprovider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster-worker-runner/tc"
+	"github.com/taskcluster/taskcluster-worker-runner/run"
+)
+
+func TestAWSConfigureRun(t *testing.T) {
+	runnerWorkerConfig := cfg.NewWorkerConfig()
+	runnerWorkerConfig, err := runnerWorkerConfig.Set("from-runner-cfg", true)
+	assert.NoError(t, err, "setting config")
+	runnercfg := &cfg.RunnerConfig{
+		Provider: cfg.ProviderConfig{
+			ProviderType: "aws",
+		},
+		WorkerImplementation: cfg.WorkerImplementationConfig{
+			Implementation: "whatever",
+		},
+		WorkerConfig: runnerWorkerConfig,
+	}
+
+	userData := &UserData{
+		WorkerPoolId: "w/p",
+		ProviderId:   "amazon",
+		WorkerGroup:  "wg",
+		RootURL:      "https://tc.example.com",
+	}
+
+	metaData := map[string]string{
+		"/dynamic/instance-identity/signature": "thisisasignature",
+	}
+
+	instanceIdentityDocument := "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}"
+
+
+	mds := &fakeMetadataService{nil, userData, metaData, instanceIdentityDocument}
+
+	p, err := new(runnercfg, tc.FakeWorkerManagerClientFactory, mds)
+	assert.NoError(t, err, "creating provider")
+
+	state := run.State{
+		WorkerConfig: runnercfg.WorkerConfig,
+	}
+	err = p.ConfigureRun(&state)
+	if !assert.NoError(t, err, "ConfigureRun") {
+		return
+	}
+
+	reg, err := tc.FakeWorkerManagerRegistration()
+	if assert.NoError(t, err) {
+		assert.Equal(t, userData.ProviderId, reg.ProviderID)
+		assert.Equal(t, userData.WorkerGroup, reg.WorkerGroup)
+		assert.Equal(t, "i-55555nonesense5", reg.WorkerID)
+		assert.Equal(t, json.RawMessage(`{"document":"{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}","signature":"thisisasignature"}`), reg.WorkerIdentityProof)
+		assert.Equal(t, "w/p", reg.WorkerPoolID)
+	}
+
+	assert.Equal(t, "https://tc.example.com", state.RootURL, "rootURL is correct")
+	assert.Equal(t, "testing", state.Credentials.ClientID, "clientID is correct")
+	assert.Equal(t, "at", state.Credentials.AccessToken, "accessToken is correct")
+	assert.Equal(t, "cert", state.Credentials.Certificate, "cert is correct")
+	assert.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
+	assert.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
+	assert.Equal(t, "i-55555nonesense5", state.WorkerID, "workerID is correct")
+
+	assert.Equal(t, map[string]string{
+		"instance-id": "i-55555nonesense5",
+		"image": "banana",
+		"instance-type": "t2.micro",
+		"availability-zone": "us-west-2a",
+		"region": "us-west-2",
+	}, state.ProviderMetadata, "providerMetadata is correct")
+
+	assert.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
+}

--- a/provider/awsprovider/metadata.go
+++ b/provider/awsprovider/metadata.go
@@ -11,18 +11,18 @@ var EC2MetadataBaseURL = "http://169.254.169.254/latest"
 
 type UserData struct {
 	WorkerPoolId string `json:"workerPoolId"`
-	ProviderId string `json:"providerId"`
-	RootURL string `json:"rootUrl"`
-	WorkerGroup string `json:"workerGroup"`
+	ProviderId   string `json:"providerId"`
+	RootURL      string `json:"rootUrl"`
+	WorkerGroup  string `json:"workerGroup"`
 }
 
 type InstanceIdentityDocument struct {
-	InstanceId string `json:"instanceId"`
-	ImageId string `json:"imageId"`
-	InstanceType string `json:"instanceType"`
-	Region string `json:"region"`
+	InstanceId       string `json:"instanceId"`
+	ImageId          string `json:"imageId"`
+	InstanceType     string `json:"instanceType"`
+	Region           string `json:"region"`
 	AvailabilityZone string `json:"availabilityZone"`
-	PrivateIp string `json:"privateIp"`
+	PrivateIp        string `json:"privateIp"`
 }
 
 type MetadataService interface {

--- a/provider/awsprovider/metadata.go
+++ b/provider/awsprovider/metadata.go
@@ -22,6 +22,7 @@ type InstanceIdentityDocument struct {
 	InstanceType string `json:"instanceType"`
 	Region string `json:"region"`
 	AvailabilityZone string `json:"availabilityZone"`
+	PrivateIp string `json:"privateIp"`
 }
 
 type MetadataService interface {

--- a/provider/awsprovider/metadata.go
+++ b/provider/awsprovider/metadata.go
@@ -18,6 +18,10 @@ type UserData struct {
 
 type InstanceIdentityDocument struct {
 	InstanceId string `json:"instanceId"`
+	ImageId string `json:"imageId"`
+	InstanceType string `json:"instanceType"`
+	Region string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone"`
 }
 
 type MetadataService interface {

--- a/provider/awsprovider/metadata.go
+++ b/provider/awsprovider/metadata.go
@@ -1,0 +1,70 @@
+package awsprovider
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/taskcluster/httpbackoff"
+)
+
+var EC2MetadataBaseURL = "http://169.254.169.254/latest"
+
+type UserData struct {
+	WorkerPoolId string `json:"workerPoolId"`
+	ProviderId string `json:"providerId"`
+	RootURL string `json:"rootUrl"`
+	WorkerGroup string `json:"workerGroup"`
+}
+
+type InstanceIdentityDocument struct {
+	InstanceId string `json:"instanceId"`
+}
+
+type MetadataService interface {
+	// Query the UserData and return the parsed contents
+	queryUserData() (*UserData, error)
+
+	// return both parsed and unparsed instance identity document
+	queryInstanceIdentityDocument() (string, *InstanceIdentityDocument, error)
+
+	// Query an aribtrary metadata value; path is the portion following `latest`
+	queryMetadata(path string) (string, error)
+}
+
+type realMetadataService struct{}
+
+func (mds *realMetadataService) queryUserData() (*UserData, error) {
+	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-user-data-retrieval
+	content, err := mds.queryMetadata("/user-data")
+	if err != nil {
+		return nil, err
+	}
+	userData := &UserData{}
+	err = json.Unmarshal([]byte(content), userData)
+	return userData, err
+}
+
+func (mds *realMetadataService) queryMetadata(path string) (string, error) {
+	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval
+	// call http://169.254.169.254/latest/meta-data/instance-id with httpbackoff
+	resp, _, err := httpbackoff.Get(EC2MetadataBaseURL + path)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	return string(content), err
+}
+
+func (mds *realMetadataService) queryInstanceIdentityDocument() (string, *InstanceIdentityDocument, error) {
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
+	identityDocumentString, err := mds.queryMetadata("/dynamic/instance-identity/document")
+	if err != nil {
+		return "", nil, err
+	}
+
+	identityDocumentJSON := &InstanceIdentityDocument{}
+	err = json.Unmarshal([]byte(identityDocumentString), identityDocumentJSON)
+
+	return identityDocumentString, identityDocumentJSON, err
+}

--- a/provider/awsprovider/metadata_test.go
+++ b/provider/awsprovider/metadata_test.go
@@ -69,7 +69,7 @@ func TestQueryUserData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/latest/user-data" {
 			w.WriteHeader(200)
-			fmt.Fprintln(w, `{"region": "aa-central-2", "data": {"dockerConfig": {"privileged": true}}}`)
+			fmt.Fprintln(w, `{"rootUrl": "taskcluster-dev.net", "workerPoolId": "banana"}`)
 		} else {
 			w.WriteHeader(404)
 			fmt.Fprintf(w, "Not Found: %s", r.URL.Path)
@@ -86,9 +86,6 @@ func TestQueryUserData(t *testing.T) {
 
 	ud, err := ms.queryUserData()
 	require.NoError(t, err)
-	require.Equal(t, "aa-central-2", ud.Region)
-
-	privileged, err := ud.Data.Get("dockerConfig.privileged")
-	require.NoError(t, err)
-	require.Equal(t, privileged, true)
+	require.Equal(t, "taskcluster-dev.net", ud.RootURL)
+	require.Equal(t, "banana", ud.WorkerPoolId)
 }

--- a/provider/awsprovider/metadata_test.go
+++ b/provider/awsprovider/metadata_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 type fakeMetadataService struct {
-	UserDataError error
-	UserData *UserData
-	Metadata map[string]string
+	UserDataError            error
+	UserData                 *UserData
+	Metadata                 map[string]string
 	InstanceIdentityDocument string
 }
 

--- a/provider/awsprovider/metadata_test.go
+++ b/provider/awsprovider/metadata_test.go
@@ -1,0 +1,94 @@
+package awsprovider
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/httpbackoff"
+)
+
+type fakeMetadataService struct {
+	UserDataError error
+	UserData      *UserData
+	Metadata      map[string]string
+}
+
+func (mds *fakeMetadataService) queryUserData() (*UserData, error) {
+	if mds.UserDataError != nil {
+		return nil, mds.UserDataError
+	}
+	return mds.UserData, nil
+}
+
+func (mds *fakeMetadataService) queryMetadata(path string) (string, error) {
+	if path[0] != '/' {
+		panic("path must start with /")
+	}
+	res, ok := mds.Metadata[path]
+	if !ok {
+		return "", fmt.Errorf("not found")
+	}
+	return res, nil
+}
+
+func TestQueryMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/meta-data/some-data" {
+			w.WriteHeader(200)
+			fmt.Fprintln(w, "42")
+		} else {
+			w.WriteHeader(404)
+			fmt.Fprintln(w, "Not Found")
+		}
+	}))
+	defer ts.Close()
+
+	EC2MetadataBaseURL = ts.URL + "/latest"
+	defer func() {
+		EC2MetadataBaseURL = "http://169.254.169.254/latest"
+	}()
+
+	ms := realMetadataService{}
+
+	rv, err := ms.queryMetadata("/meta-data/some-data")
+	require.NoError(t, err)
+	require.Equal(t, "42\n", rv)
+
+	_, err = ms.queryMetadata("/meta-data/NOSUCH")
+	if err != nil {
+		httperr, ok := err.(httpbackoff.BadHttpResponseCode)
+		require.True(t, ok)
+		require.Equal(t, 404, httperr.HttpResponseCode)
+	}
+}
+
+func TestQueryUserData(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/user-data" {
+			w.WriteHeader(200)
+			fmt.Fprintln(w, `{"region": "aa-central-2", "data": {"dockerConfig": {"privileged": true}}}`)
+		} else {
+			w.WriteHeader(404)
+			fmt.Fprintf(w, "Not Found: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	EC2MetadataBaseURL = ts.URL + "/latest"
+	defer func() {
+		EC2MetadataBaseURL = "http://169.254.169.254/latest"
+	}()
+
+	ms := realMetadataService{}
+
+	ud, err := ms.queryUserData()
+	require.NoError(t, err)
+	require.Equal(t, "aa-central-2", ud.Region)
+
+	privileged, err := ud.Data.Get("dockerConfig.privileged")
+	require.NoError(t, err)
+	require.Equal(t, privileged, true)
+}

--- a/provider/awsprovider/metadata_test.go
+++ b/provider/awsprovider/metadata_test.go
@@ -108,7 +108,7 @@ func TestQueryInstanceIdentityDocument(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/latest/dynamic/instance-identity/document" {
 			w.WriteHeader(200)
-			fmt.Fprintf(w, "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}")
+			fmt.Fprintf(w, "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}")
 		} else {
 			w.WriteHeader(404)
 			fmt.Fprintln(w, "Not Found")
@@ -130,5 +130,6 @@ func TestQueryInstanceIdentityDocument(t *testing.T) {
 	require.Equal(t, "t2.micro", iid_json.InstanceType)
 	require.Equal(t, "us-west-2", iid_json.Region)
 	require.Equal(t, "us-west-2a", iid_json.AvailabilityZone)
-	require.Equal(t, "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n}", iid_string)
+	require.Equal(t, "1.1.1.1", iid_json.PrivateIp)
+	require.Equal(t, "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}", iid_string)
 }

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -47,7 +47,9 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 		return fmt.Errorf("Could not create worker manager client: %v", err)
 	}
 
-	err = provider.RegisterWorker(state, wm, userData.WorkerPoolID, userData.ProviderID, userData.WorkerGroup, workerID, "token", proofToken)
+	workerIdentityProofMap := map[string]interface{}{"token": interface{}(proofToken)}
+
+		err = provider.RegisterWorker(state, wm, userData.WorkerPoolID, userData.ProviderID, userData.WorkerGroup, workerID, workerIdentityProofMap)
 	if err != nil {
 		return err
 	}

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -49,7 +49,7 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 
 	workerIdentityProofMap := map[string]interface{}{"token": interface{}(proofToken)}
 
-		err = provider.RegisterWorker(state, wm, userData.WorkerPoolID, userData.ProviderID, userData.WorkerGroup, workerID, workerIdentityProofMap)
+	err = provider.RegisterWorker(state, wm, userData.WorkerPoolID, userData.ProviderID, userData.WorkerGroup, workerID, workerIdentityProofMap)
 	if err != nil {
 		return err
 	}

--- a/provider/provider/common.go
+++ b/provider/provider/common.go
@@ -11,8 +11,7 @@ import (
 )
 
 // Register this worker with the worker-manager, and update the state with the parameters and the results.
-func RegisterWorker(state *run.State, wm tc.WorkerManager, workerPoolID, providerID, workerGroup, workerID, workerIdentityKey, workerIdentityValue string) error {
-	workerIdentityProofMap := map[string]interface{}{workerIdentityKey: interface{}(workerIdentityValue)}
+func RegisterWorker(state *run.State, wm tc.WorkerManager, workerPoolID, providerID, workerGroup, workerID string, workerIdentityProofMap map[string]interface{}) error {
 	workerIdentityProof, err := json.Marshal(workerIdentityProofMap)
 	if err != nil {
 		return err

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -43,7 +43,9 @@ func (p *StaticProvider) ConfigureRun(state *run.State) error {
 		return fmt.Errorf("Could not create worker manager client: %v", err)
 	}
 
-	err = provider.RegisterWorker(state, wm, pc.WorkerPoolID, pc.ProviderID, pc.WorkerGroup, pc.WorkerID, "staticSecret", pc.StaticSecret)
+	workerIdentityProofMap := map[string]interface{}{"staticSecret": interface{}(pc.StaticSecret)}
+
+	err = provider.RegisterWorker(state, wm, pc.WorkerPoolID, pc.ProviderID, pc.WorkerGroup, pc.WorkerID, workerIdentityProofMap)
 	if err != nil {
 		return err
 	}

--- a/run/state.go
+++ b/run/state.go
@@ -27,9 +27,11 @@ type State struct {
 	WorkerID     string
 
 	// metadata from the provider (useful to display to the user for
-	// debugging).  Workers should not *require* any data to exist
-	// in this map, and where possible should just pass it along as-is
-	// in worker config as helpful debugging metadata for the user.
+	// debugging).  This is also a public API for docker-worker,
+	// which doesn't, strictly speaking, require these fields,
+	// but may fall onto undesirable defaults if these are not provided
+	// A bit more info on that here
+	// https://github.com/taskcluster/taskcluster-worker-runner/pull/30#pullrequestreview-277378260
 	ProviderMetadata map[string]string
 
 	// the accumulated WorkerConfig for this run, including files to create


### PR DESCRIPTION
I created a buggie https://bugzilla.mozilla.org/show_bug.cgi?id=1575094

Also, I'm not sure what provider metadata is useful for debugging, so I just put in there some stuff that's similar to what is done for gcp. Some metadata that gcp has is about networking, and aws iid don't have that (except for private ip which I'm uncomfortable exposing). We would need to make another aws api call to get that..... I decided to leave that out for now - we can always add that if we need to