### PR TITLE
Bug 1574656 - merge workerGroup config from worker-manager

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/taskcluster/httpbackoff v1.0.0 h1:bdh5txPv6geBVSEcx7Jy3kqiBaIrCZJwzCotPJKf9DU=
 github.com/taskcluster/httpbackoff v1.0.0/go.mod h1:DEx05B3r52XQRbgzZ5y6XorMjVXBhtoHgc/ap+yLXgY=

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -83,6 +83,8 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
+	state.WorkerConfig = state.WorkerConfig.Merge(userData.WorkerConfig)
+
 	return nil
 }
 

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
@@ -13,7 +14,7 @@ import (
 func TestGoogleConfigureRun(t *testing.T) {
 	runnerWorkerConfig := cfg.NewWorkerConfig()
 	runnerWorkerConfig, err := runnerWorkerConfig.Set("from-runner-cfg", true)
-	assert.NoError(t, err, "setting config")
+	require.NoError(t, err, "setting config")
 	runnercfg := &cfg.RunnerConfig{
 		Provider: cfg.ProviderConfig{
 			ProviderType: "google",
@@ -24,11 +25,16 @@ func TestGoogleConfigureRun(t *testing.T) {
 		WorkerConfig: runnerWorkerConfig,
 	}
 
+	userDataWorkerConfig := cfg.NewWorkerConfig()
+	userDataWorkerConfig, err = userDataWorkerConfig.Set("from-ud", true)
+	require.NoError(t, err, "setting config")
+
 	userData := &UserData{
 		WorkerPoolID: "w/p",
 		ProviderID:   "gcp1",
 		WorkerGroup:  "wg",
 		RootURL:      "https://tc.example.com",
+		WorkerConfig: userDataWorkerConfig,
 	}
 	identityPath := "/instance/service-accounts/default/identity?audience=https://tc.example.com&format=full"
 	metaData := map[string]string{
@@ -45,34 +51,32 @@ func TestGoogleConfigureRun(t *testing.T) {
 	mds := &fakeMetadataService{nil, userData, metaData}
 
 	p, err := new(runnercfg, tc.FakeWorkerManagerClientFactory, mds)
-	assert.NoError(t, err, "creating provider")
+	require.NoError(t, err, "creating provider")
 
 	state := run.State{
 		WorkerConfig: runnercfg.WorkerConfig,
 	}
 	err = p.ConfigureRun(&state)
-	if !assert.NoError(t, err, "ConfigureRun") {
-		return
-	}
+	require.NoError(t, err, "ConfigureRun")
 
 	reg, err := tc.FakeWorkerManagerRegistration()
 	if assert.NoError(t, err) {
-		assert.Equal(t, userData.ProviderID, reg.ProviderID)
-		assert.Equal(t, userData.WorkerGroup, reg.WorkerGroup)
-		assert.Equal(t, "i-123", reg.WorkerID)
-		assert.Equal(t, json.RawMessage(`{"token":"i-promise"}`), reg.WorkerIdentityProof)
-		assert.Equal(t, "w/p", reg.WorkerPoolID)
+		require.Equal(t, userData.ProviderID, reg.ProviderID)
+		require.Equal(t, userData.WorkerGroup, reg.WorkerGroup)
+		require.Equal(t, "i-123", reg.WorkerID)
+		require.Equal(t, json.RawMessage(`{"token":"i-promise"}`), reg.WorkerIdentityProof)
+		require.Equal(t, "w/p", reg.WorkerPoolID)
 	}
 
-	assert.Equal(t, "https://tc.example.com", state.RootURL, "rootURL is correct")
-	assert.Equal(t, "testing", state.Credentials.ClientID, "clientID is correct")
-	assert.Equal(t, "at", state.Credentials.AccessToken, "accessToken is correct")
-	assert.Equal(t, "cert", state.Credentials.Certificate, "cert is correct")
-	assert.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
-	assert.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
-	assert.Equal(t, "i-123", state.WorkerID, "workerID is correct")
+	require.Equal(t, "https://tc.example.com", state.RootURL, "rootURL is correct")
+	require.Equal(t, "testing", state.Credentials.ClientID, "clientID is correct")
+	require.Equal(t, "at", state.Credentials.AccessToken, "accessToken is correct")
+	require.Equal(t, "cert", state.Credentials.Certificate, "cert is correct")
+	require.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
+	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
+	require.Equal(t, "i-123", state.WorkerID, "workerID is correct")
 
-	assert.Equal(t, map[string]string{
+	require.Equal(t, map[string]string{
 		"project-id":      "proj-1234",
 		"image":           "img-123",
 		"instance-type":   "most-of-the-cloud",
@@ -84,5 +88,6 @@ func TestGoogleConfigureRun(t *testing.T) {
 		"local-ipv4":      "192.168.0.1",
 	}, state.ProviderMetadata, "providerMetadata is correct")
 
-	assert.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
+	require.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
+	require.Equal(t, true, state.WorkerConfig.MustGet("from-ud"), true)
 }

--- a/provider/google/metadata.go
+++ b/provider/google/metadata.go
@@ -8,16 +8,18 @@ import (
 	"net/http"
 
 	"github.com/taskcluster/httpbackoff"
+	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 )
 
 var metadataBaseURL = "http://metadata.google.internal/computeMetadata/v1"
 
 // user-data sent to us from the worker-manager service
 type UserData struct {
-	WorkerPoolID string `json:"workerPoolId"`
-	ProviderID   string `json:"providerId"`
-	WorkerGroup  string `json:"workerGroup"`
-	RootURL      string `json:"rootUrl"`
+	WorkerPoolID string            `json:"workerPoolId"`
+	ProviderID   string            `json:"providerId"`
+	WorkerGroup  string            `json:"workerGroup"`
+	RootURL      string            `json:"rootUrl"`
+	WorkerConfig *cfg.WorkerConfig `json:"workerConfig"`
 }
 
 type MetadataService interface {

--- a/provider/google/metadata_test.go
+++ b/provider/google/metadata_test.go
@@ -76,7 +76,7 @@ func TestQueryUserData(t *testing.T) {
 			fmt.Fprintln(w, "Metadata-Flavor Missing")
 		} else if r.URL.Path == "/computeMetadata/v1/instance/attributes/taskcluster" {
 			w.WriteHeader(200)
-			fmt.Fprintln(w, `{"workerPoolId": "w/p"}`)
+			fmt.Fprintln(w, `{"workerPoolId": "w/p", "workerConfig": {"from-worker-config": true}}`)
 		} else {
 			w.WriteHeader(404)
 			fmt.Fprintf(w, "Not Found: %s", r.URL.Path)
@@ -94,5 +94,6 @@ func TestQueryUserData(t *testing.T) {
 	ud, err := ms.queryUserData()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "w/p", ud.WorkerPoolID)
+		assert.Equal(t, true, ud.WorkerConfig.MustGet("from-worker-config"))
 	}
 }


### PR DESCRIPTION
This should accept the `workerConfig` field in the instance metadata.

(this also gets the `require` religion in one test file)