### PR TITLE
Update module taskcluster/taskcluster/clients/client-go/v16 to v17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/taskcluster/httpbackoff/v3 v3.0.0
 	github.com/taskcluster/slugid-go v1.1.0
-	github.com/taskcluster/taskcluster/clients/client-go/v16 v16.2.0
+	github.com/taskcluster/taskcluster/clients/client-go/v17 v17.0.0
 	golang.org/x/text v0.3.2 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93 h1:NnAUCP75PRm8yWE7+MZBIAR6PA9iwsBYEc6ZNYOy+AQ=
 github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93/go.mod h1:TK+jB3mBs+8ZMWhU5BqZKnZWJ1MrLo8etNVg51ueTBo=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -26,12 +24,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/streadway/amqp v0.0.0-20190819003559-eade30b20f1d/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/streadway/amqp v0.0.0-20190827080102-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/taskcluster/httpbackoff v1.0.0 h1:bdh5txPv6geBVSEcx7Jy3kqiBaIrCZJwzCotPJKf9DU=
-github.com/taskcluster/httpbackoff v1.0.0/go.mod h1:DEx05B3r52XQRbgzZ5y6XorMjVXBhtoHgc/ap+yLXgY=
 github.com/taskcluster/httpbackoff/v3 v3.0.0 h1:Zh2BCW2iA3fzBBuZo2E4MvwyPSB6aimyI4EreeK3TRM=
 github.com/taskcluster/httpbackoff/v3 v3.0.0/go.mod h1:99ubellEC0fmRj7wnGkPftT2xfCY7NmbjT3gzn2ZPUM=
 github.com/taskcluster/jsonschema2go v1.0.0 h1:ZEDj2NKh8Sceq36zyLhSV6ann/aNXKZIe9cAXq7CDdk=
@@ -43,11 +39,11 @@ github.com/taskcluster/taskcluster-base-go v1.0.0 h1:Jh2R/J7+a23LjtYEHQtkFV04QBx
 github.com/taskcluster/taskcluster-base-go v1.0.0/go.mod h1:ByyzyqqufsfZTrAHUw+0Grp8FwZAizZOKzVE1IpDXxQ=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible h1:57WLzh7B04y6ahTOJ8wjvdkbwYqnyJkwLXQ1Tu4E/DU=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
-github.com/taskcluster/taskcluster/clients/client-go/v16 v16.2.0 h1:h/vAGikMa6RedCSH5VV084QQKGG9HDCz3dfTwftCtyc=
-github.com/taskcluster/taskcluster/clients/client-go/v16 v16.2.0/go.mod h1:XVuJuVfKWpJx0Gh5WgFYxM1r4n8sQ4vM7idgC0gQroY=
+github.com/taskcluster/taskcluster/clients/client-go/v17 v17.0.0 h1:y3GqEdBjty09pwYV63CTKDggrn2DM4VbHfWIs0tmHc4=
+github.com/taskcluster/taskcluster/clients/client-go/v17 v17.0.0/go.mod h1:shpgbD7cBFgdZDPajxA5+XHojTf6TrNc28mVMzMoiyg=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957 h1:6Fre/uvwovW5YY4nfHZk66cAg9HjT9YdFSAJHUUgOyQ=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957/go.mod h1:dch7ywQEefE1ibFqBG1erFibrdUIwovcwQjksYuHuP4=
-github.com/xeipuuv/gojsonpointer v0.0.0-20190812004523-df4f5c81cb3b/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -62,8 +58,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190722020823-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=

--- a/provider/awsprovider/awsprovider.go
+++ b/provider/awsprovider/awsprovider.go
@@ -8,8 +8,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 type AWSProvider struct {

--- a/provider/awsprovisioner/awsprovisioner.go
+++ b/provider/awsprovisioner/awsprovisioner.go
@@ -12,8 +12,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcawsprovisioner"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcawsprovisioner"
 )
 
 type AwsProvisionerProvider struct {

--- a/provider/awsprovisioner/awsprovisioner_test.go
+++ b/provider/awsprovisioner/awsprovisioner_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcawsprovisioner"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcawsprovisioner"
 )
 
 var testMetadata = map[string]string{

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -9,8 +9,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 type GoogleProvider struct {

--- a/provider/provider/common.go
+++ b/provider/provider/common.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 // Register this worker with the worker-manager, and update the state with the parameters and the results.

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -8,8 +8,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 type staticProviderConfig struct {

--- a/run/state.go
+++ b/run/state.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/files"
-	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v16"
+	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v17"
 )
 
 // State represents the state of the worker run.  Its contents are built up

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -11,8 +11,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcsecrets"
 )
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.Secrets, error) {

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcsecrets"
 )
 
 func setup(t *testing.T) (*cfg.RunnerConfig, *run.State) {

--- a/tc/awsprovisioner.go
+++ b/tc/awsprovisioner.go
@@ -1,8 +1,8 @@
 package tc
 
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcawsprovisioner"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcawsprovisioner"
 )
 
 // An interface containing the functions required of AwsProvisioner, allowing

--- a/tc/fakeawsprovisioner.go
+++ b/tc/fakeawsprovisioner.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/taskcluster/slugid-go/slugid"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcawsprovisioner"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcawsprovisioner"
 )
 
 var (

--- a/tc/fakeawsprovisioner_test.go
+++ b/tc/fakeawsprovisioner_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcawsprovisioner"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcawsprovisioner"
 )
 
 func TestAwsProvisionerSecretsGetNosuch(t *testing.T) {

--- a/tc/fakesecrets.go
+++ b/tc/fakesecrets.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/taskcluster/httpbackoff/v3"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcsecrets"
 )
 
 var (

--- a/tc/fakesecrets_test.go
+++ b/tc/fakesecrets_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/taskcluster/httpbackoff/v3"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcsecrets"
 )
 
 func TestSecretsSecretsGetNosuch(t *testing.T) {

--- a/tc/fakeworkermanager.go
+++ b/tc/fakeworkermanager.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 var (

--- a/tc/fakeworkermanager_test.go
+++ b/tc/fakeworkermanager_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 func TestWorkerManagerRegisterWorker(t *testing.T) {

--- a/tc/secrets.go
+++ b/tc/secrets.go
@@ -1,8 +1,8 @@
 package tc
 
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcsecrets"
 )
 
 // An interface containing the functions required of Secrets, allowing

--- a/tc/workermanager.go
+++ b/tc/workermanager.go
@@ -1,8 +1,8 @@
 package tc
 
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v16"
-	"github.com/taskcluster/taskcluster/clients/client-go/v16/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v17"
+	"github.com/taskcluster/taskcluster/clients/client-go/v17/tcworkermanager"
 )
 
 // An interface containing the functions required of WorkerManager, allowing


### PR DESCRIPTION
this fixes an issue where we had conflicting versions of httpbackoff imported