### PR TITLE
Implement user data config for standalone provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ provider:
     workerID: ..
     # custom properties for TASKCLUSTER_WORKER_LOCATION
     workerLocation:  {prop: val, ..}
+    # custom worker configuration
+    userData:
+        prop: value
+        ...
 ```
 
 The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)

--- a/cfg/providerconfig.go
+++ b/cfg/providerconfig.go
@@ -72,7 +72,10 @@ func (pc *ProviderConfig) Unpack(out interface{}) error {
 		destfield := destval.Field(i)
 		gotval := reflect.ValueOf(val)
 		if destfield.Type() != gotval.Type() {
-			return fmt.Errorf("Configuration value `provider.%s` should have type %s", name, destfield.Type())
+			return fmt.Errorf(
+				"Configuration value `provider.%s` should have type %s, but it has type %s",
+				name, destfield.Type(), gotval.Type(),
+			)
 		}
 		destfield.Set(gotval)
 	}

--- a/cfg/workerconfig.go
+++ b/cfg/workerconfig.go
@@ -203,7 +203,7 @@ func (wc *WorkerConfig) Get(key string) (interface{}, error) {
 		}
 		val, ok = valmap[k]
 		if !ok {
-			return nil, fmt.Errorf("key not found")
+			return nil, fmt.Errorf("key '%s' not found", k)
 		}
 	}
 	return val, nil

--- a/provider/standalone/standalone_test.go
+++ b/provider/standalone/standalone_test.go
@@ -26,6 +26,11 @@ func TestConfigureRun(t *testing.T) {
 					"region": "underworld",
 					"zone":   "666",
 				},
+				"userData": map[interface{}]interface{}{
+					"dockerConfig": map[interface{}]interface{}{
+						"privileged": true,
+					},
+				},
 			},
 		},
 		WorkerImplementation: cfg.WorkerImplementationConfig{
@@ -51,6 +56,7 @@ func TestConfigureRun(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "wi", state.WorkerID, "workerID is correct")
 	require.Equal(t, map[string]string{}, state.ProviderMetadata, "providerMetadata is correct")
+	require.Equal(t, true, state.WorkerConfig.MustGet("dockerConfig.privileged"))
 
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
 	require.Equal(t, "standalone", state.WorkerLocation["cloud"])


### PR DESCRIPTION
Workers might need specific configurations according to the environment
it runs. For example, we need to pass the `privileged` config to
docker-worker under packet.net

This commit adds the `userData` configuration for custom configurations
in standalone provider.