### PR TITLE
Require a well-formed rootURL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/taskcluster/httpbackoff/v3 v3.0.0
 	github.com/taskcluster/slugid-go v1.1.0
+	github.com/taskcluster/taskcluster-lib-urls v12.1.0+incompatible
 	github.com/taskcluster/taskcluster/clients/client-go/v23 v23.0.0
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/taskcluster/taskcluster-base-go v1.0.0 h1:Jh2R/J7+a23LjtYEHQtkFV04QBx
 github.com/taskcluster/taskcluster-base-go v1.0.0/go.mod h1:ByyzyqqufsfZTrAHUw+0Grp8FwZAizZOKzVE1IpDXxQ=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible h1:57WLzh7B04y6ahTOJ8wjvdkbwYqnyJkwLXQ1Tu4E/DU=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
+github.com/taskcluster/taskcluster-lib-urls v12.1.0+incompatible h1:YzwkIlgCZXbJHfg23GJCJ/kgSRh44btr5wEAviGUqVA=
+github.com/taskcluster/taskcluster-lib-urls v12.1.0+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
 github.com/taskcluster/taskcluster/clients/client-go/v17 v17.0.0 h1:y3GqEdBjty09pwYV63CTKDggrn2DM4VbHfWIs0tmHc4=
 github.com/taskcluster/taskcluster/clients/client-go/v17 v17.0.0/go.mod h1:shpgbD7cBFgdZDPajxA5+XHojTf6TrNc28mVMzMoiyg=
 github.com/taskcluster/taskcluster/clients/client-go/v18 v18.0.1 h1:nKTJgDfWUGa/Hna8q+8XADrLy6QavabNWRdvChc2aos=

--- a/provider/standalone/standalone.go
+++ b/provider/standalone/standalone.go
@@ -1,6 +1,7 @@
 package standalone
 
 import (
+	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
@@ -27,7 +28,7 @@ func (p *StandaloneProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
-	state.RootURL = pc.RootURL
+	state.RootURL = tcurls.NormalizeRootURL(pc.RootURL)
 	state.Credentials.ClientID = pc.ClientID
 	state.Credentials.AccessToken = pc.AccessToken
 	state.WorkerPoolID = pc.WorkerPoolID

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -3,6 +3,7 @@ package static
 import (
 	"fmt"
 
+	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
@@ -34,7 +35,7 @@ func (p *StaticProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
-	state.RootURL = pc.RootURL
+	state.RootURL = tcurls.NormalizeRootURL(pc.RootURL)
 
 	// We need a worker manager client for fetching taskcluster credentials.
 	// Ensure auth is disabled in client, since we don't have credentials yet.

--- a/run/state.go
+++ b/run/state.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
@@ -56,6 +57,10 @@ type State struct {
 func (state *State) CheckProviderResults() error {
 	if state.RootURL == "" {
 		return fmt.Errorf("provider did not set RootURL")
+	}
+
+	if strings.HasSuffix(state.RootURL, "/") {
+		return fmt.Errorf("RootURL must not end with `/`")
 	}
 
 	if state.Credentials.ClientID == "" {

--- a/run/state_test.go
+++ b/run/state_test.go
@@ -1,0 +1,65 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v23"
+)
+
+func makeState() State {
+	return State{
+		RootURL: "https://tc.example.com",
+		Credentials: taskcluster.Credentials{
+			ClientID: "cli",
+		},
+		WorkerPoolID: "wp/id",
+		WorkerGroup:  "wg",
+		WorkerID:     "wid",
+		WorkerLocation: map[string]string{
+			"cloud": "mushroom",
+		},
+	}
+}
+
+func TestCheckProviderResultsNoRootURL(t *testing.T) {
+	state := makeState()
+	state.RootURL = ""
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsRootURLwithSlash(t *testing.T) {
+	state := makeState()
+	state.RootURL = "https://tc.example.com/"
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsNoClientID(t *testing.T) {
+	state := makeState()
+	state.Credentials.ClientID = ""
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsNoWorkerPoolID(t *testing.T) {
+	state := makeState()
+	state.WorkerPoolID = ""
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsNoWorkerGroup(t *testing.T) {
+	state := makeState()
+	state.WorkerGroup = ""
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsNoWorkerID(t *testing.T) {
+	state := makeState()
+	state.WorkerID = ""
+	require.Error(t, state.CheckProviderResults())
+}
+
+func TestCheckProviderResultsNoCloud(t *testing.T) {
+	state := makeState()
+	delete(state.WorkerLocation, "cloud")
+	require.Error(t, state.CheckProviderResults())
+}


### PR DESCRIPTION
I decided to just require this to be well-formatted, rather than silently normalizing it.