### PR TITLE
Bug 1558532 - build windows and darwin binaries, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /start-worker
-start-worker-linux-amd64
+start-worker-*-*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+build() {
+    local output=start-worker-${1}-${2}
+    GOOS="${1}" GOARCH="${2}" CGO_ENABLED=0 go build -o $output ./cmd/start-worker
+    echo $output
+}
+echo "Building:"
+build linux amd64
+build windows amd64
+build windows 386
+build darwin amd64
+

--- a/release.sh
+++ b/release.sh
@@ -19,13 +19,8 @@ git add version.go README.md
 git commit -m "v$VERSION"
 git tag v$VERSION
 
-build() {
-    local output=start-worker-${1}-${2}
-    GOOS="${1}" GOARCH="${2}" CGO_ENABLED=0 go build -o $output ./cmd/start-worker
-    echo $output
-}
-echo "Building:"
-build linux amd64
+source ./build.sh
+
 echo "* Git push with --follow-tags to the upstream repo"
 echo "* Create a new release from the tag"
-echo "* Attach the above built binary to the release"
+echo "* Attach the above built binaries to the release"


### PR DESCRIPTION
I used this to build binaries for the 0.7.0 release and they worked fine.