### PR TITLE
Bug 1602960 - handle complex worker config from providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ highest precedence, these are:
 Providers can supply configuration to the worker via whatever means makes sense.
 For example, an EC2 or GCP provider would read configuration from the instance's userData.
 
+### Provider Configuration
+
+Providers that interact with the worker-manager service can get configuration from that service.
+That configuration formally has the form:
+
+```yaml
+worker:
+  config:
+    workerConfigValue: ...
+  files:
+    - ...
+```
+
+Where all fields are optional.  The contents of `worker.config` are merged into the worker configuration.
+Files are handled as described below.
+
+For backward compatibility, `worker` can also be spelled `genericWorker`; the two are treated interchangeably.
+Also for backward compatibility, configuration may be specified as a simple object with configuration properties at the top level.
+Both of these forms are deprecated, and support will be removed in a future version.
+
 ### Secrets
 
 Secrets are stored in the secrets service under a secret named
@@ -71,7 +91,7 @@ Two backward-compatibility measures exist:
 
 ### Files
 
-Files can also be stored in the secrets service, under the `files` property described above.
+Files can also be stored in the secrets service and in provider configuration, under the `files` properties described above.
 These can be used to write (small) files to disk on the worker before it starts up.
 For example:
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,30 @@ Providers that interact with the worker-manager service can get configuration fr
 That configuration formally has the form:
 
 ```yaml
-worker:
+<workerImplementation>:
   config:
     workerConfigValue: ...
   files:
     - ...
 ```
 
-Where all fields are optional.  The contents of `worker.config` are merged into the worker configuration.
+Where all fields are optional.
+The `<workerImplementation>` is replaced with the worker implementation name, in camel case (`genericWorker`, `dockerWorker`, etc.)
+The contents of `<workerImplementation>.config` are merged into the worker configuration.
 Files are handled as described below.
 
-For backward compatibility, `worker` can also be spelled `genericWorker`; the two are treated interchangeably.
-Also for backward compatibility, configuration may be specified as a simple object with configuration properties at the top level.
-Both of these forms are deprecated, and support will be removed in a future version.
+For backward compatibility, configuration may be specified as a simple object with configuration properties at the top level.
+Support for this form will be removed in future versions.
+
+Putting all of this together, a worker pool definition for a generic-worker instance might contain:
+```yaml
+launchConfigs:
+- ...
+  workerConfig:
+    genericWorker:
+      config:
+        shutdownMachineOnInternalError: true
+```
 
 ### Secrets
 

--- a/cfg/providerworkerconfig.go
+++ b/cfg/providerworkerconfig.go
@@ -1,0 +1,70 @@
+package cfg
+
+import (
+	"encoding/json"
+
+	"github.com/taskcluster/taskcluster-worker-runner/files"
+)
+
+// ProviderWorkerConfig handles the configuration format provided from
+// worker-manager providers: `{worker: {config, files}}`, including some
+// compatibility translations described in the README.
+type ProviderWorkerConfig struct {
+	Config *WorkerConfig `json:"config,omitempty"`
+	Files  []files.File  `json:"files,omitempty"`
+}
+
+type expectedConfig struct {
+	Worker *struct {
+		Config *WorkerConfig `json:"config"`
+		Files  []files.File  `json:"files"`
+	} `json:"worker"`
+}
+
+// compatibility with the old {genericWorker: {config, files}} format
+type gwConfig struct {
+	GenericWorker *struct {
+		Config *WorkerConfig `json:"config"`
+		Files  []files.File  `json:"files"`
+	} `json:"genericWorker"`
+}
+
+func (pwc *ProviderWorkerConfig) UnmarshalJSON(b []byte) error {
+	var expected = expectedConfig{}
+	err := json.Unmarshal(b, &expected)
+	if err == nil && expected.Worker != nil {
+		pwc.Config = expected.Worker.Config
+		pwc.Files = expected.Worker.Files
+		return nil
+	}
+
+	// compatibility 1: genericWorker -> worker
+	var gw = gwConfig{}
+	err = json.Unmarshal(b, &gw)
+	if err == nil && gw.GenericWorker != nil {
+		pwc.Config = gw.GenericWorker.Config
+		pwc.Files = gw.GenericWorker.Files
+		return nil
+	}
+
+	// compatibility 2: flat form
+	var config = WorkerConfig{}
+	err = json.Unmarshal(b, &config)
+	if err == nil {
+		pwc.Config = &config
+		pwc.Files = []files.File{}
+		return nil
+	}
+
+	return err
+}
+
+func (pwc ProviderWorkerConfig) MarshalJSON() ([]byte, error) {
+	rv := map[string]interface{}{
+		"worker": map[string]interface{}{
+			"config": pwc.Config,
+			"files":  pwc.Files,
+		},
+	}
+	return json.Marshal(rv)
+}

--- a/cfg/providerworkerconfig_test.go
+++ b/cfg/providerworkerconfig_test.go
@@ -5,36 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/taskcluster/taskcluster-worker-runner/files"
 )
 
-func TestPWCCorrectForm(t *testing.T) {
-	var pwc ProviderWorkerConfig
-
-	err := json.Unmarshal([]byte(`{
-      "worker": {
-	    "config": {
-		  "someValue": true
+func makeRunnerConfig(implementation string) *RunnerConfig {
+	return &RunnerConfig{
+		WorkerImplementation: WorkerImplementationConfig{
+			Implementation: implementation,
 		},
-		"files": [
-		  {
-			"description": "my file"
-		  }
-		]
-	  }
-	}`), &pwc)
-	if err != nil {
-		t.Fatalf("failed to load: %s", err)
 	}
-	require.Equal(t, true, pwc.Config.MustGet("someValue"))
-	require.Equal(t, "my file", pwc.Files[0].Description)
 }
 
-func TestPWCCompatibilityGenericWorkerForm(t *testing.T) {
-	var pwc ProviderWorkerConfig
-
-	err := json.Unmarshal([]byte(`{
-      "genericWorker": {
+func TestPWCCorrectForm(t *testing.T) {
+	runnercfg := makeRunnerConfig("test-worker")
+	message := json.RawMessage(`{
+      "testWorker": {
 	    "config": {
 		  "someValue": true
 		},
@@ -44,63 +28,37 @@ func TestPWCCompatibilityGenericWorkerForm(t *testing.T) {
 		  }
 		]
 	  }
-	}`), &pwc)
-	if err != nil {
-		t.Fatalf("failed to load: %s", err)
-	}
+	}`)
+	pwc, err := ParseProviderWorkerConfig(runnercfg, &message)
+	require.NoError(t, err)
 	require.Equal(t, true, pwc.Config.MustGet("someValue"))
 	require.Equal(t, "my file", pwc.Files[0].Description)
 }
 
 func TestPWCCompatibilityFlatFormForm(t *testing.T) {
-	var pwc ProviderWorkerConfig
-
-	err := json.Unmarshal([]byte(`{
+	runnercfg := makeRunnerConfig("test-worker")
+	message := json.RawMessage(`{
 	  "someValue": true
-	}`), &pwc)
-	if err != nil {
-		t.Fatalf("failed to load: %s", err)
-	}
+	}`)
+	pwc, err := ParseProviderWorkerConfig(runnercfg, &message)
+	require.NoError(t, err)
 	require.Equal(t, true, pwc.Config.MustGet("someValue"))
 	require.Equal(t, 0, len(pwc.Files))
 }
 
-func TestPWCBadForm(t *testing.T) {
-	var pwc ProviderWorkerConfig
-
-	// This is sort of unfortunate, but inputs that don't map precisely to the
-	// expected form are instead treated as the old flat form, rather than being
-	// seen as an error.  When we drop support for the flat form, this will be
-	// handled more naturally.
-	err := json.Unmarshal([]byte(`{
-      "worker": {
-	    "config": true,
-		"files": []
-	  }
-	}`), &pwc)
-	if err != nil {
-		t.Fatalf("failed to load: %s", err)
-	}
-	require.Equal(t, true, pwc.Config.MustGet("worker.config"))
+func TestPWCEmpty(t *testing.T) {
+	runnercfg := makeRunnerConfig("test-worker")
+	pwc, err := ParseProviderWorkerConfig(runnercfg, nil)
+	require.NoError(t, err)
+	require.Nil(t, pwc.Config)
+	require.Equal(t, 0, len(pwc.Files))
 }
 
-func TestPWCMarshal(t *testing.T) {
-	var wc = NewWorkerConfig()
-	wc, _ = wc.Set("some-value", true)
-	pwc := ProviderWorkerConfig{
-		Config: wc,
-		Files: []files.File{
-			files.File{
-				Description: "my file",
-			},
-		},
-	}
-
-	marsh, err := json.Marshal(pwc)
-	require.NoError(t, err)
-
-	var pwc2 ProviderWorkerConfig
-	err = json.Unmarshal(marsh, &pwc2)
-	require.NoError(t, err)
-	require.Equal(t, pwc, pwc2)
+func TestPWCBadForm(t *testing.T) {
+	// we'll parse just about anything as a worker config, but if the top
+	// level is not an object, that's an error
+	runnercfg := makeRunnerConfig("test-worker")
+	message := json.RawMessage(`"I am a string"`)
+	_, err := ParseProviderWorkerConfig(runnercfg, &message)
+	require.Error(t, err)
 }

--- a/cfg/providerworkerconfig_test.go
+++ b/cfg/providerworkerconfig_test.go
@@ -1,0 +1,106 @@
+package cfg
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster-worker-runner/files"
+)
+
+func TestPWCCorrectForm(t *testing.T) {
+	var pwc ProviderWorkerConfig
+
+	err := json.Unmarshal([]byte(`{
+      "worker": {
+	    "config": {
+		  "someValue": true
+		},
+		"files": [
+		  {
+			"description": "my file"
+		  }
+		]
+	  }
+	}`), &pwc)
+	if err != nil {
+		t.Fatalf("failed to load: %s", err)
+	}
+	require.Equal(t, true, pwc.Config.MustGet("someValue"))
+	require.Equal(t, "my file", pwc.Files[0].Description)
+}
+
+func TestPWCCompatibilityGenericWorkerForm(t *testing.T) {
+	var pwc ProviderWorkerConfig
+
+	err := json.Unmarshal([]byte(`{
+      "genericWorker": {
+	    "config": {
+		  "someValue": true
+		},
+		"files": [
+		  {
+			"description": "my file"
+		  }
+		]
+	  }
+	}`), &pwc)
+	if err != nil {
+		t.Fatalf("failed to load: %s", err)
+	}
+	require.Equal(t, true, pwc.Config.MustGet("someValue"))
+	require.Equal(t, "my file", pwc.Files[0].Description)
+}
+
+func TestPWCCompatibilityFlatFormForm(t *testing.T) {
+	var pwc ProviderWorkerConfig
+
+	err := json.Unmarshal([]byte(`{
+	  "someValue": true
+	}`), &pwc)
+	if err != nil {
+		t.Fatalf("failed to load: %s", err)
+	}
+	require.Equal(t, true, pwc.Config.MustGet("someValue"))
+	require.Equal(t, 0, len(pwc.Files))
+}
+
+func TestPWCBadForm(t *testing.T) {
+	var pwc ProviderWorkerConfig
+
+	// This is sort of unfortunate, but inputs that don't map precisely to the
+	// expected form are instead treated as the old flat form, rather than being
+	// seen as an error.  When we drop support for the flat form, this will be
+	// handled more naturally.
+	err := json.Unmarshal([]byte(`{
+      "worker": {
+	    "config": true,
+		"files": []
+	  }
+	}`), &pwc)
+	if err != nil {
+		t.Fatalf("failed to load: %s", err)
+	}
+	require.Equal(t, true, pwc.Config.MustGet("worker.config"))
+}
+
+func TestPWCMarshal(t *testing.T) {
+	var wc = NewWorkerConfig()
+	wc, _ = wc.Set("some-value", true)
+	pwc := ProviderWorkerConfig{
+		Config: wc,
+		Files: []files.File{
+			files.File{
+				Description: "my file",
+			},
+		},
+	}
+
+	marsh, err := json.Marshal(pwc)
+	require.NoError(t, err)
+
+	var pwc2 ProviderWorkerConfig
+	err = json.Unmarshal(marsh, &pwc2)
+	require.NoError(t, err)
+	require.Equal(t, pwc, pwc2)
+}

--- a/provider/aws/awsprovider.go
+++ b/provider/aws/awsprovider.go
@@ -93,8 +93,13 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(userData.ProviderWorkerConfig.Config)
-	state.Files = append(state.Files, userData.ProviderWorkerConfig.Files...)
+	pwc, err := cfg.ParseProviderWorkerConfig(p.runnercfg, userData.ProviderWorkerConfig)
+	if err != nil {
+		return err
+	}
+
+	state.WorkerConfig = state.WorkerConfig.Merge(pwc.Config)
+	state.Files = append(state.Files, pwc.Files...)
 
 	return nil
 }

--- a/provider/aws/awsprovider.go
+++ b/provider/aws/awsprovider.go
@@ -93,7 +93,8 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(userData.WorkerConfig)
+	state.WorkerConfig = state.WorkerConfig.Merge(userData.ProviderWorkerConfig.Config)
+	state.Files = append(state.Files, userData.ProviderWorkerConfig.Files...)
 
 	return nil
 }

--- a/provider/aws/awsprovider_test.go
+++ b/provider/aws/awsprovider_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
-	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
@@ -21,28 +20,27 @@ func TestAWSConfigureRun(t *testing.T) {
 			ProviderType: "aws",
 		},
 		WorkerImplementation: cfg.WorkerImplementationConfig{
-			Implementation: "whatever",
+			Implementation: "whatever-worker",
 		},
 		WorkerConfig: runnerWorkerConfig,
 	}
 
-	userDataWorkerConfig := cfg.NewWorkerConfig()
-	userDataWorkerConfig, err = userDataWorkerConfig.Set("from-ud", true)
-	require.NoError(t, err, "setting config")
-
-	userData := &UserData{
-		WorkerPoolId: "w/p",
-		ProviderId:   "amazon",
-		WorkerGroup:  "wg",
-		RootURL:      "https://tc.example.com",
-		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
-			Config: userDataWorkerConfig,
-			Files: []files.File{
-				files.File{
-					Description: "a file.",
-				},
+	pwcJson := json.RawMessage(`{
+        "whateverWorker": {
+		    "config": {
+				"from-ud": true
 			},
-		},
+			"files": [
+			    {"description": "a file."}
+			]
+		}
+	}`)
+	userData := &UserData{
+		WorkerPoolId:         "w/p",
+		ProviderId:           "amazon",
+		WorkerGroup:          "wg",
+		RootURL:              "https://tc.example.com",
+		ProviderWorkerConfig: &pwcJson,
 	}
 
 	metaData := map[string]string{

--- a/provider/aws/awsprovider_test.go
+++ b/provider/aws/awsprovider_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
@@ -34,7 +35,14 @@ func TestAWSConfigureRun(t *testing.T) {
 		ProviderId:   "amazon",
 		WorkerGroup:  "wg",
 		RootURL:      "https://tc.example.com",
-		WorkerConfig: userDataWorkerConfig,
+		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
+			Config: userDataWorkerConfig,
+			Files: []files.File{
+				files.File{
+					Description: "a file.",
+				},
+			},
+		},
 	}
 
 	metaData := map[string]string{
@@ -85,6 +93,7 @@ func TestAWSConfigureRun(t *testing.T) {
 
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-ud"), "value for worker-config")
+	require.Equal(t, "a file.", state.Files[0].Description)
 
 	require.Equal(t, "aws", state.WorkerLocation["cloud"])
 	require.Equal(t, "us-west-2", state.WorkerLocation["region"])

--- a/provider/aws/metadata.go
+++ b/provider/aws/metadata.go
@@ -5,17 +5,16 @@ import (
 	"io/ioutil"
 
 	"github.com/taskcluster/httpbackoff/v3"
-	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 )
 
 var EC2MetadataBaseURL = "http://169.254.169.254/latest"
 
 type UserData struct {
-	WorkerPoolId         string                    `json:"workerPoolId"`
-	ProviderId           string                    `json:"providerId"`
-	RootURL              string                    `json:"rootUrl"`
-	WorkerGroup          string                    `json:"workerGroup"`
-	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
+	WorkerPoolId         string           `json:"workerPoolId"`
+	ProviderId           string           `json:"providerId"`
+	RootURL              string           `json:"rootUrl"`
+	WorkerGroup          string           `json:"workerGroup"`
+	ProviderWorkerConfig *json.RawMessage `json:"workerConfig"`
 }
 
 type InstanceIdentityDocument struct {

--- a/provider/aws/metadata.go
+++ b/provider/aws/metadata.go
@@ -11,11 +11,11 @@ import (
 var EC2MetadataBaseURL = "http://169.254.169.254/latest"
 
 type UserData struct {
-	WorkerPoolId string            `json:"workerPoolId"`
-	ProviderId   string            `json:"providerId"`
-	RootURL      string            `json:"rootUrl"`
-	WorkerGroup  string            `json:"workerGroup"`
-	WorkerConfig *cfg.WorkerConfig `json:"workerConfig"`
+	WorkerPoolId         string                    `json:"workerPoolId"`
+	ProviderId           string                    `json:"providerId"`
+	RootURL              string                    `json:"rootUrl"`
+	WorkerGroup          string                    `json:"workerGroup"`
+	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
 }
 
 type InstanceIdentityDocument struct {

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -25,11 +25,11 @@ type AzureProvider struct {
 }
 
 type CustomData struct {
-	WorkerPoolId string            `json:"workerPoolId"`
-	ProviderId   string            `json:"providerId"`
-	RootURL      string            `json:"rootUrl"`
-	WorkerGroup  string            `json:"workerGroup"`
-	WorkerConfig *cfg.WorkerConfig `json:"workerConfig"`
+	WorkerPoolId         string                    `json:"workerPoolId"`
+	ProviderId           string                    `json:"providerId"`
+	RootURL              string                    `json:"rootUrl"`
+	WorkerGroup          string                    `json:"workerGroup"`
+	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
 }
 
 func (p *AzureProvider) ConfigureRun(state *run.State) error {
@@ -98,7 +98,8 @@ func (p *AzureProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(customData.WorkerConfig)
+	state.WorkerConfig = state.WorkerConfig.Merge(customData.ProviderWorkerConfig.Config)
+	state.Files = append(state.Files, customData.ProviderWorkerConfig.Files...)
 
 	return nil
 }

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -25,11 +25,11 @@ type AzureProvider struct {
 }
 
 type CustomData struct {
-	WorkerPoolId         string                    `json:"workerPoolId"`
-	ProviderId           string                    `json:"providerId"`
-	RootURL              string                    `json:"rootUrl"`
-	WorkerGroup          string                    `json:"workerGroup"`
-	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
+	WorkerPoolId         string           `json:"workerPoolId"`
+	ProviderId           string           `json:"providerId"`
+	RootURL              string           `json:"rootUrl"`
+	WorkerGroup          string           `json:"workerGroup"`
+	ProviderWorkerConfig *json.RawMessage `json:"workerConfig"`
 }
 
 func (p *AzureProvider) ConfigureRun(state *run.State) error {
@@ -98,8 +98,13 @@ func (p *AzureProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(customData.ProviderWorkerConfig.Config)
-	state.Files = append(state.Files, customData.ProviderWorkerConfig.Files...)
+	pwc, err := cfg.ParseProviderWorkerConfig(p.runnercfg, customData.ProviderWorkerConfig)
+	if err != nil {
+		return err
+	}
+
+	state.WorkerConfig = state.WorkerConfig.Merge(pwc.Config)
+	state.Files = append(state.Files, pwc.Files...)
 
 	return nil
 }

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
-	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
@@ -23,28 +22,27 @@ func TestConfigureRun(t *testing.T) {
 			ProviderType: "azure",
 		},
 		WorkerImplementation: cfg.WorkerImplementationConfig{
-			Implementation: "whatever",
+			Implementation: "whatever-worker",
 		},
 		WorkerConfig: runnerWorkerConfig,
 	}
 
-	userDataWorkerConfig := cfg.NewWorkerConfig()
-	userDataWorkerConfig, err = userDataWorkerConfig.Set("from-ud", true)
-	require.NoError(t, err, "setting config")
-
-	customData := CustomData{
-		WorkerPoolId: "w/p",
-		ProviderId:   "amazon",
-		WorkerGroup:  "wg",
-		RootURL:      "https://tc.example.com",
-		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
-			Config: userDataWorkerConfig,
-			Files: []files.File{
-				files.File{
-					Description: "a file.",
-				},
+	pwcJson := json.RawMessage(`{
+        "whateverWorker": {
+		    "config": {
+				"from-ud": true
 			},
-		},
+			"files": [
+			    {"description": "a file."}
+			]
+		}
+	}`)
+	customData := CustomData{
+		WorkerPoolId:         "w/p",
+		ProviderId:           "amazon",
+		WorkerGroup:          "wg",
+		RootURL:              "https://tc.example.com",
+		ProviderWorkerConfig: &pwcJson,
 	}
 	customDataJson, err := json.Marshal(customData)
 	require.NoError(t, err, "marshalling CustomData")

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
@@ -36,7 +37,14 @@ func TestConfigureRun(t *testing.T) {
 		ProviderId:   "amazon",
 		WorkerGroup:  "wg",
 		RootURL:      "https://tc.example.com",
-		WorkerConfig: userDataWorkerConfig,
+		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
+			Config: userDataWorkerConfig,
+			Files: []files.File{
+				files.File{
+					Description: "a file.",
+				},
+			},
+		},
 	}
 	customDataJson, err := json.Marshal(customData)
 	require.NoError(t, err, "marshalling CustomData")

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -91,7 +91,8 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(userData.WorkerConfig)
+	state.WorkerConfig = state.WorkerConfig.Merge(userData.ProviderWorkerConfig.Config)
+	state.Files = append(state.Files, userData.ProviderWorkerConfig.Files...)
 
 	return nil
 }

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -91,8 +91,13 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	state.WorkerConfig = state.WorkerConfig.Merge(userData.ProviderWorkerConfig.Config)
-	state.Files = append(state.Files, userData.ProviderWorkerConfig.Files...)
+	pwc, err := cfg.ParseProviderWorkerConfig(p.runnercfg, userData.ProviderWorkerConfig)
+	if err != nil {
+		return err
+	}
+
+	state.WorkerConfig = state.WorkerConfig.Merge(pwc.Config)
+	state.Files = append(state.Files, pwc.Files...)
 
 	return nil
 }

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
 )
@@ -34,7 +35,14 @@ func TestGoogleConfigureRun(t *testing.T) {
 		ProviderID:   "gcp1",
 		WorkerGroup:  "wg",
 		RootURL:      "https://tc.example.com",
-		WorkerConfig: userDataWorkerConfig,
+		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
+			Config: userDataWorkerConfig,
+			Files: []files.File{
+				files.File{
+					Description: "a file.",
+				},
+			},
+		},
 	}
 	identityPath := "/instance/service-accounts/default/identity?audience=https://tc.example.com&format=full"
 	metaData := map[string]string{
@@ -90,6 +98,7 @@ func TestGoogleConfigureRun(t *testing.T) {
 
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-ud"), "value for worker-config")
+	require.Equal(t, "a file.", state.Files[0].Description)
 
 	require.Equal(t, "google", state.WorkerLocation["cloud"])
 	require.Equal(t, "in-central1", state.WorkerLocation["region"])

--- a/provider/google/google_test.go
+++ b/provider/google/google_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
-	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
 )
@@ -21,28 +20,27 @@ func TestGoogleConfigureRun(t *testing.T) {
 			ProviderType: "google",
 		},
 		WorkerImplementation: cfg.WorkerImplementationConfig{
-			Implementation: "whatever",
+			Implementation: "whatever-worker",
 		},
 		WorkerConfig: runnerWorkerConfig,
 	}
 
-	userDataWorkerConfig := cfg.NewWorkerConfig()
-	userDataWorkerConfig, err = userDataWorkerConfig.Set("from-ud", true)
-	require.NoError(t, err, "setting config")
-
-	userData := &UserData{
-		WorkerPoolID: "w/p",
-		ProviderID:   "gcp1",
-		WorkerGroup:  "wg",
-		RootURL:      "https://tc.example.com",
-		ProviderWorkerConfig: &cfg.ProviderWorkerConfig{
-			Config: userDataWorkerConfig,
-			Files: []files.File{
-				files.File{
-					Description: "a file.",
-				},
+	pwcJson := json.RawMessage(`{
+        "whateverWorker": {
+		    "config": {
+				"from-ud": true
 			},
-		},
+			"files": [
+			    {"description": "a file."}
+			]
+		}
+	}`)
+	userData := &UserData{
+		WorkerPoolID:         "w/p",
+		ProviderID:           "gcp1",
+		WorkerGroup:          "wg",
+		RootURL:              "https://tc.example.com",
+		ProviderWorkerConfig: &pwcJson,
 	}
 	identityPath := "/instance/service-accounts/default/identity?audience=https://tc.example.com&format=full"
 	metaData := map[string]string{

--- a/provider/google/metadata.go
+++ b/provider/google/metadata.go
@@ -8,18 +8,17 @@ import (
 	"net/http"
 
 	"github.com/taskcluster/httpbackoff/v3"
-	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 )
 
 var metadataBaseURL = "http://metadata.google.internal/computeMetadata/v1"
 
 // user-data sent to us from the worker-manager service
 type UserData struct {
-	WorkerPoolID         string                    `json:"workerPoolId"`
-	ProviderID           string                    `json:"providerId"`
-	WorkerGroup          string                    `json:"workerGroup"`
-	RootURL              string                    `json:"rootUrl"`
-	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
+	WorkerPoolID         string           `json:"workerPoolId"`
+	ProviderID           string           `json:"providerId"`
+	WorkerGroup          string           `json:"workerGroup"`
+	RootURL              string           `json:"rootUrl"`
+	ProviderWorkerConfig *json.RawMessage `json:"workerConfig"`
 }
 
 type MetadataService interface {

--- a/provider/google/metadata.go
+++ b/provider/google/metadata.go
@@ -15,11 +15,11 @@ var metadataBaseURL = "http://metadata.google.internal/computeMetadata/v1"
 
 // user-data sent to us from the worker-manager service
 type UserData struct {
-	WorkerPoolID string            `json:"workerPoolId"`
-	ProviderID   string            `json:"providerId"`
-	WorkerGroup  string            `json:"workerGroup"`
-	RootURL      string            `json:"rootUrl"`
-	WorkerConfig *cfg.WorkerConfig `json:"workerConfig"`
+	WorkerPoolID         string                    `json:"workerPoolId"`
+	ProviderID           string                    `json:"providerId"`
+	WorkerGroup          string                    `json:"workerGroup"`
+	RootURL              string                    `json:"rootUrl"`
+	ProviderWorkerConfig *cfg.ProviderWorkerConfig `json:"workerConfig"`
 }
 
 type MetadataService interface {

--- a/provider/google/metadata_test.go
+++ b/provider/google/metadata_test.go
@@ -94,6 +94,6 @@ func TestQueryUserData(t *testing.T) {
 	ud, err := ms.queryUserData()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "w/p", ud.WorkerPoolID)
-		assert.Equal(t, true, ud.WorkerConfig.MustGet("from-worker-config"))
+		assert.Equal(t, true, ud.ProviderWorkerConfig.Config.MustGet("from-worker-config"))
 	}
 }

--- a/provider/google/metadata_test.go
+++ b/provider/google/metadata_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -94,6 +95,6 @@ func TestQueryUserData(t *testing.T) {
 	ud, err := ms.queryUserData()
 	if assert.NoError(t, err) {
 		assert.Equal(t, "w/p", ud.WorkerPoolID)
-		assert.Equal(t, true, ud.ProviderWorkerConfig.Config.MustGet("from-worker-config"))
+		assert.Equal(t, json.RawMessage(`{"from-worker-config": true}`), *ud.ProviderWorkerConfig)
 	}
 }


### PR DESCRIPTION
This adds support for workerConfig in worker-manager pool definitions of
the form

```yaml
workerConfig:
  worker:
    config:
      someValue: true
    files:
      - description: blah
        path: /a/b/c
        content: <..base64..>
```

with some compatibility for the existing ways of passing configuration
to docker-worker (flat) and generic-worker (similar to above but with
"worker" replaced with "genericWorker").