### PR TITLE
Bug 1606750 - ensure - and include warning about - config cache permisisons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/google/uuid v1.1.1 // indirect
+	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 h1:S4qyfL2sEm5Budr4KVMyEniCy+PbS55651I/a+Kn/NQ=
+github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95/go.mod h1:QiyDdbZLaJ/mZP4Zwc9g2QsfaEA4o7XvvgZegSci5/E=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -100,6 +102,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191218084908-4a24b4065292 h1:Y8q0zsdcgAd+JU8VUA8p8Qv2YhuY9zevDG2ORt5qBUI=
 golang.org/x/sys v0.0.0-20191218084908-4a24b4065292/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/perms/perms_posix.go
+++ b/perms/perms_posix.go
@@ -1,0 +1,56 @@
+// +build linux darwin
+
+package perms
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// MakePrivateToOwner ensures that the given file is private to the
+// file owner.
+func MakePrivateToOwner(filename string) (err error) {
+	if filename == "" {
+		// regression check for
+		// https://bugzilla.mozilla.org/show_bug.cgi?id=1594353
+		panic("empty filename passed to MakePrivateToOwner")
+	}
+
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+
+	uid := int(stat.Sys().(*syscall.Stat_t).Uid)
+	if uid != os.Getuid() {
+		err = os.Chown(filename, os.Getuid(), -1)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.Chmod(filename, 0600)
+	return
+}
+
+// VerifyPrivateToOwner verifies that the given file can only be read by the
+// file's owner, returning an error if this is not the case, or cannot be
+// determined.
+func VerifyPrivateToOwner(filename string) error {
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return err
+	}
+
+	uid := int(stat.Sys().(*syscall.Stat_t).Uid)
+	if uid != os.Getuid() {
+		return fmt.Errorf("%s has incorrect owner id %d", filename, uid)
+	}
+	// (note: we don't check gid since the group has no permission to the file)
+
+	if stat.Mode() != os.FileMode(0600) {
+		return fmt.Errorf("%s has mode %#o, not 0600", filename, stat.Mode())
+	}
+	return nil
+}

--- a/perms/perms_posix_test.go
+++ b/perms/perms_posix_test.go
@@ -1,0 +1,14 @@
+// +build linux darwin
+
+package perms
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makePermsBad(t *testing.T, filename string) {
+	require.NoError(t, os.Chmod(filename, 0666))
+}

--- a/perms/perms_test.go
+++ b/perms/perms_test.go
@@ -1,0 +1,37 @@
+package perms
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/Flaque/filet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermsGood(t *testing.T) {
+	defer filet.CleanUp(t)
+
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "test")
+	require.NoError(t, ioutil.WriteFile(filename, []byte("hi"), 0644))
+	makePermsBad(t, filename)
+
+	err := MakePrivateToOwner(filename)
+	require.NoError(t, err)
+
+	err = VerifyPrivateToOwner(filename)
+	require.NoError(t, err)
+}
+
+func TestPermsBad(t *testing.T) {
+	defer filet.CleanUp(t)
+
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "test")
+	require.NoError(t, ioutil.WriteFile(filename, []byte("hi"), 0644))
+	makePermsBad(t, filename)
+
+	err := VerifyPrivateToOwner(filename)
+	require.Error(t, err)
+}

--- a/perms/perms_windows.go
+++ b/perms/perms_windows.go
@@ -1,0 +1,126 @@
+// +build windows
+
+package perms
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+const OWNER_ONLY_SDDL = "D:PAI(A;;FA;;;OW)"
+const NOBODY = "S-1-0-0"
+
+// MakePrivateToOwner ensures that the given file is private to the
+// current user.
+func MakePrivateToOwner(filename string) (err error) {
+	if filename == "" {
+		panic("empty filename passed to MakePrivateToOwner")
+	}
+
+	// get the current user's SID, which we will make the owner
+	currentUser, err := getCurrentUser()
+	if err != nil {
+		return
+	}
+
+	// Use the well-known SID for "No security principal" as group
+	group, err := windows.StringToSid(NOBODY)
+	if err != nil {
+		return
+	}
+
+	// and create a DACL (D:) protected from inheritance (P) and automatically
+	// inherited by children (AI) that allows (A) full access (FA) to the owner
+	// (OW).
+	si, err := windows.SecurityDescriptorFromString(OWNER_ONLY_SDDL)
+	if err != nil {
+		panic(err)
+	}
+	dacl, _, err := si.DACL()
+	if err != nil {
+		panic(err)
+	}
+
+	// use all of that to set the owner, group, and dacl for the file.
+	err = windows.SetNamedSecurityInfo(
+		filename,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|
+			windows.GROUP_SECURITY_INFORMATION|
+			// note that the "P" in the dacl isn't enough; this bit protects
+			// from inheriting parent objects' permissions
+			windows.PROTECTED_DACL_SECURITY_INFORMATION|
+			windows.DACL_SECURITY_INFORMATION,
+		currentUser,
+		group,
+		dacl,
+		nil)
+
+	return
+}
+
+// VerifyPrivateToOwner verifies that the given file can only be read by the
+// file's owner, returning an error if this is not the case, or cannot be
+// determined.
+func VerifyPrivateToOwner(filename string) (err error) {
+	// We want to check the owner, group, and DACL for this file.  The DACL
+	// will be verified in its SDDL form, while the owner and group are
+	// checked directly.
+	si, err := windows.GetNamedSecurityInfo(
+		filename,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return
+	}
+
+	if si.String() != OWNER_ONLY_SDDL {
+		return fmt.Errorf("File did not have expected DACL; got %s, expected %s", si, OWNER_ONLY_SDDL)
+	}
+
+	si, err = windows.GetNamedSecurityInfo(
+		filename,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.GROUP_SECURITY_INFORMATION)
+	if err != nil {
+		return
+	}
+
+	owner, _, err := si.Owner()
+	if err != nil {
+		return
+	}
+	group, _, err := si.Group()
+	if err != nil {
+		return
+	}
+
+	currentUser, err := getCurrentUser()
+	if err != nil {
+		return
+	}
+
+	if owner.String() != currentUser.String() {
+		return fmt.Errorf("File did not have expcted owner; got %s, expected %s", owner, currentUser)
+	}
+
+	if group.String() != NOBODY {
+		return fmt.Errorf("File did not have expcted group; got %s, expected %s", group, NOBODY)
+	}
+
+	return
+}
+
+// Get the SID of the current user
+func getCurrentUser() (sid *windows.SID, err error) {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return
+	}
+	defer token.Close()
+
+	tokenuser, err := token.GetTokenUser()
+	sid = tokenuser.User.Sid
+	return
+}

--- a/perms/perms_windows_test.go
+++ b/perms/perms_windows_test.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package perms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func makePermsBad(t *testing.T, filename string) {
+	// allow access to anonymous.. that seems bad..
+	si, err := windows.SecurityDescriptorFromString("D:PAI(A;;FA;;;OW)(A;;FA;;;AN)")
+	require.NoError(t, err)
+
+	dacl, _, err := si.DACL()
+	require.NoError(t, err)
+
+	// use all of that to set the owner, group, and dacl for the file.
+	require.NoError(t, windows.SetNamedSecurityInfo(
+		filename,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil))
+}

--- a/runner/run.go
+++ b/runner/run.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/hectane/go-acl"
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/credexp"
 	"github.com/taskcluster/taskcluster-worker-runner/files"
@@ -114,6 +115,16 @@ func Run(configFile string) (state run.State, err error) {
 			return
 		}
 		err = ioutil.WriteFile(runnercfg.CacheOverRestarts, encoded, 0700)
+		if err != nil {
+			return
+		}
+
+		// This file contains secrets, so ensure that this is really only
+		// accessible to the file owner (and having just created the file, that
+		// should be the current user).  This uses go-acl so that it works on
+		// Windows, as well -- the `ioutil` used above ignores the permissions
+		// on Windows.
+		err = acl.Chmod(runnercfg.CacheOverRestarts, 0700)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
The permissions are already created correctly in [runner](https://github.com/taskcluster/taskcluster-worker-runner/blob/master/runner/run.go#L116), so this is just a README change after all.