### PR TITLE
Bug 1608185 - proto.WaitUntilInitialized()

### DIFF
--- a/credexp/credexp_test.go
+++ b/credexp/credexp_test.go
@@ -21,6 +21,7 @@ func TestCredsExpiration(t *testing.T) {
 	transp := protocol.NewFakeTransport()
 	proto := protocol.NewProtocol(transp)
 	proto.Capabilities.Add("graceful-termination")
+	proto.SetInitialized()
 
 	ce.SetProtocol(proto)
 

--- a/protocol.md
+++ b/protocol.md
@@ -46,6 +46,9 @@ on startup and nothing more.
 
 If a worker is run outside of a taskcluster-worker-runner context, it will never see the `welcome` message and thus never write `hello` or any other message.
 
+A connection is considered "initialized" on the `hello` message has been sent (on a worker) or received (on start-worker).
+Before the connection is initialized, the connection's capabilities are unknown, so protocol users should wait until initialization before querying capabilities.
+
 ## Messages
 
 The following sections describe the defined message types, each under a heading giving the corresponding capability.

--- a/provider/aws/awsprovider_test.go
+++ b/provider/aws/awsprovider_test.go
@@ -101,6 +101,7 @@ func TestAWSConfigureRun(t *testing.T) {
 func TestCheckTerminationTime(t *testing.T) {
 	transp := protocol.NewFakeTransport()
 	proto := protocol.NewProtocol(transp)
+	proto.SetInitialized()
 
 	metaData := map[string]string{}
 	instanceIdentityDocument := "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}"

--- a/provider/azure/azure_test.go
+++ b/provider/azure/azure_test.go
@@ -114,6 +114,7 @@ func TestConfigureRun(t *testing.T) {
 func TestCheckTerminationTime(t *testing.T) {
 	transp := protocol.NewFakeTransport()
 	proto := protocol.NewProtocol(transp)
+	proto.SetInitialized()
 
 	evts := &ScheduledEvents{}
 

--- a/worker/dummy/dummy.go
+++ b/worker/dummy/dummy.go
@@ -32,6 +32,8 @@ func (d *dummy) StartWorker(state *run.State) (protocol.Transport, error) {
 }
 
 func (d *dummy) SetProtocol(proto *protocol.Protocol) {
+	// the protocol is running on a null transport, so mark it as initialized
+	proto.SetInitialized()
 }
 
 func (d *dummy) Wait() error {


### PR DESCRIPTION
This introduces a way to wait for the capabilities negotation to
complete on a protocol, and uses this by default to wait before
verifying `proto.Capable(..)`.  This should help in cases where a
protocol capability is needed early in the worker startup process, such
as reporting a startup error.  It eliminates race conditions that might
otherwise occur in that context.