### PR TITLE
fix worker-location links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository defines a utility for running workers.
 It handles:
 
  - Getting Taskcluster credentials
- - Interacting with the [worker manager](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+ - Interacting with the [worker manager](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
  - Gathering configuration from various sources
  - Polling for interruptions of cloud instances (e.g., spot termination)
 
@@ -198,7 +198,7 @@ provider:
     providerType: aws
 ```
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: aws
@@ -215,7 +215,7 @@ provider:
     providerType: azure
 ```
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: azure
@@ -231,7 +231,7 @@ provider:
     providerType: google
 ```
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: google
@@ -263,7 +263,7 @@ provider:
     workerLocation:  {prop: val, ..}
 ```
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: standalone
@@ -291,7 +291,7 @@ provider:
     workerLocation:  {prop: val, ..}
 ```
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: static

--- a/provider/aws/awsprovider.go
+++ b/provider/aws/awsprovider.go
@@ -167,7 +167,7 @@ provider:
     providerType: aws
 ` + "```" + `
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: aws

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -192,7 +192,7 @@ provider:
     providerType: azure
 ` + "```" + `
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: azure

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -137,7 +137,7 @@ provider:
     providerType: google
 ` + "```" + `
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: google

--- a/provider/standalone/standalone.go
+++ b/provider/standalone/standalone.go
@@ -104,7 +104,7 @@ provider:
     workerLocation:  {prop: val, ..}
 ` + "```" + `
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: standalone

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -121,7 +121,7 @@ provider:
     workerLocation:  {prop: val, ..}
 ` + "```" + `
 
-The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/reference/core/worker-manager/)
+The [$TASKCLUSTER_WORKER_LOCATION](https://docs.taskcluster.net/docs/manual/design/env-vars#taskcluster_worker_location)
 defined by this provider has the following fields:
 
 * cloud: static


### PR DESCRIPTION
This is now documented in the "Standard Environment Variables" docs page, so let's point there.