### PR TITLE
Bug 1616028 - upgrade go client to v25

### DIFF
--- a/provider/aws/awsprovider.go
+++ b/provider/aws/awsprovider.go
@@ -11,8 +11,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 const TERMINATION_PATH = "/meta-data/spot/termination-time"

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -11,8 +11,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 type AzureProvider struct {

--- a/provider/google/google.go
+++ b/provider/google/google.go
@@ -9,8 +9,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 type GoogleProvider struct {

--- a/provider/provider/common.go
+++ b/provider/provider/common.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 // Register this worker with the worker-manager, and update the state with the parameters and the results.

--- a/provider/static/static.go
+++ b/provider/static/static.go
@@ -9,8 +9,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/provider/provider"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 type staticProviderConfig struct {

--- a/run/state.go
+++ b/run/state.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/files"
-	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v24"
+	taskcluster "github.com/taskcluster/taskcluster/v25/clients/client-go"
 )
 
 // State represents the state of the worker run.  Its contents are built up

--- a/run/state_test.go
+++ b/run/state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	taskcluster "github.com/taskcluster/taskcluster/clients/client-go/v24"
+	taskcluster "github.com/taskcluster/taskcluster/v25/clients/client-go"
 )
 
 func makeState() State {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -11,8 +11,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
 )
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.Secrets, error) {

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/taskcluster/taskcluster-worker-runner/cfg"
 	"github.com/taskcluster/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster-worker-runner/tc"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
 )
 
 func setup(t *testing.T) (*cfg.RunnerConfig, *run.State) {

--- a/tc/fakesecrets.go
+++ b/tc/fakesecrets.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/taskcluster/httpbackoff/v3"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
 )
 
 var (

--- a/tc/fakesecrets_test.go
+++ b/tc/fakesecrets_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/taskcluster/httpbackoff/v3"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
 )
 
 func TestSecretsSecretsGetNosuch(t *testing.T) {

--- a/tc/fakeworkermanager.go
+++ b/tc/fakeworkermanager.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 var (

--- a/tc/fakeworkermanager_test.go
+++ b/tc/fakeworkermanager_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 func TestWorkerManagerRegisterWorker(t *testing.T) {

--- a/tc/secrets.go
+++ b/tc/secrets.go
@@ -1,8 +1,8 @@
 package tc
 
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcsecrets"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
 )
 
 // An interface containing the functions required of Secrets, allowing

--- a/tc/workermanager.go
+++ b/tc/workermanager.go
@@ -1,8 +1,8 @@
 package tc
 
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcworkermanager"
+	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcworkermanager"
 )
 
 // An interface containing the functions required of WorkerManager, allowing


### PR DESCRIPTION
Note we have some [build failures in the monorepo](https://community-tc.services.mozilla.com/tasks/adVnabZ_QjaTGKIlucprpw/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FadVnabZ_QjaTGKIlucprpw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L1993) due to a problem with v24 of the go client. Upgrading to v25 will make migration of taskcluster-worker-runner to the monorepo a much simpler affair.